### PR TITLE
Add int8 weight-only quantized Linear Layer

### DIFF
--- a/example_xla.py
+++ b/example_xla.py
@@ -38,6 +38,7 @@ def load(
     dim: int = 4096,
     n_layers: int = 32,
     n_heads: int = 32,
+    quant: bool = False,
 ) -> LLaMA:
     start_time = time.time()
     print("Loading")
@@ -55,6 +56,7 @@ def load(
         params = {"dim": dim,
                   "n_layers": n_layers,
                   "n_heads": n_heads,
+                  "quant": quant,
                   }
 
     model_args: ModelArgs = ModelArgs(
@@ -87,13 +89,14 @@ def main(
     dim: int = 4096,
     n_layers: int = 32,
     n_heads: int = 32,
+    quant: bool = False,
 ):
     rank, world_size = setup_model_parallel()
     if rank > 0:
         sys.stdout = open(os.devnull, "w")
 
     generator = load(
-        ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, dim, n_layers, n_heads
+        ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, dim, n_layers, n_heads, quant
     )
 
     prompts = [
@@ -145,8 +148,9 @@ def _fn(
     dim: int = 4096,
     n_layers: int = 32,
     n_heads: int = 32,
+    quant: bool = False,
 ):
-    main(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads)
+    main(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads, quant)
 
 def mp_main(
     mp: bool,
@@ -159,11 +163,12 @@ def mp_main(
     dim: int = 4096,
     n_layers: int = 32,
     n_heads: int = 32,
+    quant: bool = False,
 ):
     if mp:
-        xmp.spawn(_fn, args=(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads))
+        xmp.spawn(_fn, args=(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads, quant))
     else:
-        main(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads)
+        main(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads, quant)
 
 
 if __name__ == "__main__":

--- a/llama/model.py
+++ b/llama/model.py
@@ -17,6 +17,7 @@ from .xla_model_parallel import (
     ColumnParallelLinearQuant,
     RowParallelLinear,
     ColumnParallelLinear,
+    get_model_parallel_group,
     get_model_parallel_world_size,
     get_model_parallel_rank,
 )
@@ -196,7 +197,7 @@ class FeedForward(nn.Module):
         world_size: Optional[int] = None,
         rank: Optional[int] = None,
         groups: Optional[List] = None,
-        quant: bool,
+        quant: bool = False,
     ):
         super().__init__()
         hidden_dim = int(2 * hidden_dim / 3)

--- a/llama/model.py
+++ b/llama/model.py
@@ -71,11 +71,12 @@ def apply_rotary_emb(
     xk: torch.Tensor,
     freqs_cis: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
-    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
-    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
-    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
-    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+    xq_ = torch.view_as_complex(xq.float().reshape(-1, int(xq.shape[-1]/2), 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(-1, int(xq.shape[-1]/2), 2))
+    xq_out = torch.view_as_real(xq_ * freqs_cis)
+    xk_out = torch.view_as_real(xk_ * freqs_cis)
+    xq_out = xq_out.reshape(xq.shape)
+    xk_out = xk_out.reshape(xk.shape)
     return xq_out.type_as(xq), xk_out.type_as(xk)
 
 

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -290,6 +290,7 @@ class ColumnParallelLinear(torch.nn.Module):
         world_size: Optional[int] = None,
         rank: Optional[int] = None,
         groups: Optional[List] = None,
+        quant: bool = False,
     ) -> None:
         super(ColumnParallelLinear, self).__init__()
 
@@ -306,13 +307,18 @@ class ColumnParallelLinear(torch.nn.Module):
         self.in_features = in_features
         self.out_features = out_features
         self.gather_output = gather_output
+        self.quant = quant
         # Divide the weight matrix along the last dimension.
         self.output_size_per_partition = divide_and_check_no_remainder(out_features, self.world_size)
 
         # Parameters.
         # Note: torch.nn.functional.linear performs XA^T + b and as a result
         # we allocate the transpose.
-        self.weight = Parameter(torch.Tensor(self.output_size_per_partition, self.in_features))
+        if quant:
+            self.weight = Parameter(torch.empty((self.output_size_per_partition, self.in_features), dtype=torch.int8), requires_grad=False)
+            self.weight_scaler = Parameter(torch.empty(1), requires_grad=False)
+        else:
+            self.weight = Parameter(torch.Tensor(self.output_size_per_partition, self.in_features))
         if bias:
             self.bias = Parameter(torch.Tensor(self.output_size_per_partition))
             # Always initialize bias to zero.
@@ -342,103 +348,11 @@ class ColumnParallelLinear(torch.nn.Module):
         # Set up backprop all-reduce.
         input_parallel = copy_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
         # Matrix multiply.
-        output_parallel = F.linear(input_parallel, self.weight, self.bias)
-        if self.gather_output:
-            # All-gather across the partitions.
-            output = gather_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
-        else:
-            output = output_parallel
-        return output
-
-class ColumnParallelLinearQuant(torch.nn.Module):
-    """Linear layer with column parallelism.
-
-    The linear layer is defined as Y = XA + b. A is parallelized along
-    its second dimension as A = [A_1, ..., A_p].
-
-    Arguments:
-        in_features: first dimension of matrix A.
-        out_features: second dimension of matrix A.
-        bias: If true, add bias
-        gather_output: If true, call all-gether on output and make Y avaiable
-                       to all GPUs, otherwise, every GPU will have its output
-                       which is Y_i = XA_i
-        init_method: method to initialize weights. Note that bias is always set
-                     to zero.
-        stride: For the strided linear layers.
-        keep_master_weight_for_test: This was added for testing and should be
-                                     set to False. It returns the master weights
-                                     used for initialization.
-    """
-
-    def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        bias: bool = True,
-        gather_output: bool = True,
-        init_method: Callable[[torch.Tensor], torch.Tensor] = init.xavier_normal_,
-        stride: int = 1,
-        keep_master_weight_for_test: bool = False,
-        world_size: Optional[int] = None,
-        rank: Optional[int] = None,
-        groups: Optional[List] = None,
-    ) -> None:
-        super(ColumnParallelLinearQuant, self).__init__()
-
-        if world_size is None:
-            self.groups = get_model_parallel_group()
-            self.world_size = get_model_parallel_world_size()
-            self.rank = get_model_parallel_rank()
-        else:
-            self.groups = groups
-            self.world_size = world_size
-            self.rank = rank
-
-        # Keep input parameters
-        self.in_features = in_features
-        self.out_features = out_features
-        self.gather_output = gather_output
-        # Divide the weight matrix along the last dimension.
-        self.output_size_per_partition = divide_and_check_no_remainder(out_features, self.world_size)
-
-        # Parameters.
-        # Note: torch.nn.functional.linear performs XA^T + b and as a result
-        # we allocate the transpose.
-        # self.weight = Parameter(torch.Tensor(self.output_size_per_partition, self.in_features))
-        self.weight = Parameter(torch.empty((self.output_size_per_partition, self.in_features), dtype=torch.int8), requires_grad=False)
-        self.weight_scaler = Parameter(torch.empty(1), requires_grad=False)
-        if bias:
-            self.bias = Parameter(torch.Tensor(self.output_size_per_partition))
-            # Always initialize bias to zero.
-            with torch.no_grad():
-                self.bias.zero_()
-        else:
-            self.register_parameter("bias", None)
-
-        # Initialize weight.
-        self.master_weight = _initialize_affine_weight(
-            self.weight,
-            self.out_features,
-            self.in_features,
-            self.output_size_per_partition,
-            0,
-            init_method,
-            self.world_size,
-            self.rank,
-            stride=stride,
-            return_master_weight=keep_master_weight_for_test,
-        )
-
-    def get_master_weight(self) -> torch.Tensor:
-        return gather_from_model_parallel_region(self.weight.data.transpose(0, 1), self.groups, self.world_size, self.rank).transpose_(0, 1)
-
-    def forward(self, input_: torch.Tensor) -> torch.Tensor:  # type: ignore
-        # Set up backprop all-reduce.
-        input_parallel = copy_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
-        # Matrix multiply.
-        output_parallel = F.linear(input_parallel, self.weight, self.bias)
-        output_parallel = output_parallel * self.weight_scaler
+        if self.quant:
+            output_parallel = F.linear(input_parallel, self.weight, self.bias)
+            output_parallel = output_parallel * self.weight_scaler
+        else:      
+            output_parallel = F.linear(input_parallel, self.weight, self.bias)
         if self.gather_output:
             # All-gather across the partitions.
             output = gather_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
@@ -485,6 +399,7 @@ class RowParallelLinear(torch.nn.Module):
         world_size: Optional[int] = None,
         rank: Optional[int] = None,
         groups: Optional[List] = None,
+        quant: bool = False,
     ):
         super(RowParallelLinear, self).__init__()
 
@@ -501,13 +416,18 @@ class RowParallelLinear(torch.nn.Module):
         self.in_features = in_features
         self.out_features = out_features
         self.input_is_parallel = input_is_parallel
+        self.quant = quant
         # Divide the weight matrix along the last dimension.
         self.input_size_per_partition = divide_and_check_no_remainder(in_features, self.world_size)
 
         # Parameters.
         # Note: torch.nn.functional.linear performs XA^T + b and as a result
         # we allocate the transpose.
-        self.weight = Parameter(torch.Tensor(self.out_features, self.input_size_per_partition))
+        if quant:
+            self.weight = Parameter(torch.empty((self.out_features, self.input_size_per_partition), dtype=torch.int8), requires_grad=False)
+            self.weight_scaler = Parameter(torch.empty(1), requires_grad=False)
+        else:
+            self.weight = Parameter(torch.Tensor(self.out_features, self.input_size_per_partition))
         if bias:
             self.bias = Parameter(torch.Tensor(self.out_features))
             # Always initialize bias to zero.
@@ -540,115 +460,11 @@ class RowParallelLinear(torch.nn.Module):
         else:
             input_parallel = scatter_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
         # Matrix multiply.
-        output_parallel = F.linear(input_parallel, self.weight)
-        # All-reduce across all the partitions.
-        output_ = reduce_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
-        if self.bias is not None:
-            output = output_ + self.bias
+        if self.quant:
+            output_parallel = F.linear(input_parallel, self.weight, self.bias)
+            output_parallel = output_parallel * self.weight_scaler
         else:
-            output = output_
-        return output
-
-class RowParallelLinearQuant(torch.nn.Module):
-    """Linear layer with row parallelism.
-
-    The linear layer is defined as Y = XA + b. A is parallelized along
-    its first dimension and X along its second dimension as:
-               -   -
-              | A_1 |
-              | .   |
-          A = | .   |        X = [X_1, ..., X_p]
-              | .   |
-              | A_p |
-               -   -
-    Arguments:
-        in_features: first dimension of matrix A.
-        out_features: second dimension of matrix A.
-        bias: If true, add bias. Note that bias is not parallelized.
-        input_is_parallel: If true, we assume that the input is already
-                           split across the GPUs and we do not split
-                           again.
-        init_method: method to initialize weights. Note that bias is always set
-                     to zero.
-        stride: For the strided linear layers.
-        keep_master_weight_for_test: This was added for testing and should be
-                                     set to False. It returns the master weights
-                                     used for initialization.
-    """
-
-    def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        bias: bool = True,
-        input_is_parallel: bool = False,
-        init_method: Callable[[torch.Tensor], torch.Tensor] = init.xavier_normal_,
-        stride: int = 1,
-        keep_master_weight_for_test: bool = False,
-        world_size: Optional[int] = None,
-        rank: Optional[int] = None,
-        groups: Optional[List] = None,
-    ):
-        super(RowParallelLinearQuant, self).__init__()
-
-        if world_size is None:
-            self.groups = get_model_parallel_group()
-            self.world_size = get_model_parallel_world_size()
-            self.rank = get_model_parallel_rank()
-        else:
-            self.groups = groups
-            self.world_size = world_size
-            self.rank = rank
-
-        # Keep input parameters
-        self.in_features = in_features
-        self.out_features = out_features
-        self.input_is_parallel = input_is_parallel
-        # Divide the weight matrix along the last dimension.
-        self.input_size_per_partition = divide_and_check_no_remainder(in_features, self.world_size)
-
-        # Parameters.
-        # Note: torch.nn.functional.linear performs XA^T + b and as a result
-        # we allocate the transpose.
-        self.weight = Parameter(torch.empty((self.out_features, self.input_size_per_partition), dtype=torch.int8), requires_grad=False)
-        self.weight_scaler = Parameter(torch.empty(1), requires_grad=False)
-        if bias:
-            self.bias = Parameter(torch.Tensor(self.out_features))
-            # Always initialize bias to zero.
-            with torch.no_grad():
-                self.bias.zero_()
-        else:
-            self.register_parameter("bias", None)
-
-        # Initialize weight.
-        self.master_weight = _initialize_affine_weight(
-            self.weight,
-            self.out_features,
-            self.in_features,
-            self.input_size_per_partition,
-            1,
-            init_method,
-            self.world_size,
-            self.rank,
-            stride=stride,
-            return_master_weight=keep_master_weight_for_test,
-        )
-        self.groups = get_model_parallel_group()
-        self.world_size = get_model_parallel_world_size()
-        self.rank = get_model_parallel_rank()
-
-    def get_master_weight(self) -> torch.Tensor:
-        return gather_from_model_parallel_region(self.weight.data, self.groups, self.world_size, self.rank)
-
-    def forward(self, input_: torch.Tensor) -> torch.Tensor:  # type:ignore
-        # Set up backprop all-reduce.
-        if self.input_is_parallel:
-            input_parallel = input_
-        else:
-            input_parallel = scatter_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
-        # Matrix multiply.
-        output_parallel = F.linear(input_parallel, self.weight, self.bias)
-        output_parallel = output_parallel * self.weight_scaler
+            output_parallel = F.linear(input_parallel, self.weight)
         # All-reduce across all the partitions.
         output_ = reduce_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
         if self.bias is not None:

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -350,6 +350,92 @@ class ColumnParallelLinear(torch.nn.Module):
             output = output_parallel
         return output
 
+class ColumnParallelLinearQuant(torch.nn.Module):
+    """Linear layer with column parallelism.
+
+    The linear layer is defined as Y = XA + b. A is parallelized along
+    its second dimension as A = [A_1, ..., A_p].
+
+    Arguments:
+        in_features: first dimension of matrix A.
+        out_features: second dimension of matrix A.
+        bias: If true, add bias
+        gather_output: If true, call all-gether on output and make Y avaiable
+                       to all GPUs, otherwise, every GPU will have its output
+                       which is Y_i = XA_i
+        init_method: method to initialize weights. Note that bias is always set
+                     to zero.
+        stride: For the strided linear layers.
+        keep_master_weight_for_test: This was added for testing and should be
+                                     set to False. It returns the master weights
+                                     used for initialization.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        gather_output: bool = True,
+        init_method: Callable[[torch.Tensor], torch.Tensor] = init.xavier_normal_,
+        stride: int = 1,
+        keep_master_weight_for_test: bool = False,
+    ) -> None:
+        super(ColumnParallelLinearQuant, self).__init__()
+
+        # Keep input parameters
+        self.in_features = in_features
+        self.out_features = out_features
+        self.gather_output = gather_output
+        # Divide the weight matrix along the last dimension.
+        world_size = get_model_parallel_world_size()
+        self.output_size_per_partition = divide_and_check_no_remainder(out_features, world_size)
+
+        # Parameters.
+        # Note: torch.nn.functional.linear performs XA^T + b and as a result
+        # we allocate the transpose.
+        # self.weight = Parameter(torch.Tensor(self.output_size_per_partition, self.in_features))
+        self.weight = Parameter(torch.empty((self.output_size_per_partition, self.in_features), dtype=torch.int8), requires_grad=False)
+        self.weight_scaler = Parameter(torch.empty(1), requires_grad=False)
+        if bias:
+            self.bias = Parameter(torch.Tensor(self.output_size_per_partition))
+            # Always initialize bias to zero.
+            with torch.no_grad():
+                self.bias.zero_()
+        else:
+            self.register_parameter("bias", None)
+
+        # Initialize weight.
+        self.master_weight = _initialize_affine_weight(
+            self.weight,
+            self.out_features,
+            self.in_features,
+            self.output_size_per_partition,
+            0,
+            init_method,
+            stride=stride,
+            return_master_weight=keep_master_weight_for_test,
+        )
+        self.groups = get_model_parallel_group()
+        self.world_size = get_model_parallel_world_size()
+        self.rank = get_model_parallel_rank()
+
+    def get_master_weight(self) -> torch.Tensor:
+        return gather_from_model_parallel_region(self.weight.data.transpose(0, 1), self.groups, self.world_size, self.rank).transpose_(0, 1)
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:  # type: ignore
+        # Set up backprop all-reduce.
+        input_parallel = copy_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
+        # Matrix multiply.
+        fp_w = self.weight * self.weight_scaler
+        # output_parallel = F.linear(input_parallel, self.weight, self.bias)
+        output_parallel = F.linear(input_parallel, fp_w, self.bias)
+        if self.gather_output:
+            # All-gather across the partitions.
+            output = gather_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
+        else:
+            output = output_parallel
+        return output
 
 class RowParallelLinear(torch.nn.Module):
     """Linear layer with row parallelism.
@@ -446,6 +532,102 @@ class RowParallelLinear(torch.nn.Module):
             input_parallel = scatter_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
         # Matrix multiply.
         output_parallel = F.linear(input_parallel, self.weight)
+        # All-reduce across all the partitions.
+        output_ = reduce_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
+        if self.bias is not None:
+            output = output_ + self.bias
+        else:
+            output = output_
+        return output
+
+class RowParallelLinearQuant(torch.nn.Module):
+    """Linear layer with row parallelism.
+
+    The linear layer is defined as Y = XA + b. A is parallelized along
+    its first dimension and X along its second dimension as:
+               -   -
+              | A_1 |
+              | .   |
+          A = | .   |        X = [X_1, ..., X_p]
+              | .   |
+              | A_p |
+               -   -
+    Arguments:
+        in_features: first dimension of matrix A.
+        out_features: second dimension of matrix A.
+        bias: If true, add bias. Note that bias is not parallelized.
+        input_is_parallel: If true, we assume that the input is already
+                           split across the GPUs and we do not split
+                           again.
+        init_method: method to initialize weights. Note that bias is always set
+                     to zero.
+        stride: For the strided linear layers.
+        keep_master_weight_for_test: This was added for testing and should be
+                                     set to False. It returns the master weights
+                                     used for initialization.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        input_is_parallel: bool = False,
+        init_method: Callable[[torch.Tensor], torch.Tensor] = init.xavier_normal_,
+        stride: int = 1,
+        keep_master_weight_for_test: bool = False,
+    ):
+        super(RowParallelLinearQuant, self).__init__()
+
+        # Keep input parameters
+        self.in_features = in_features
+        self.out_features = out_features
+        self.input_is_parallel = input_is_parallel
+        # Divide the weight matrix along the last dimension.
+        world_size = get_model_parallel_world_size()
+        self.input_size_per_partition = divide_and_check_no_remainder(in_features, world_size)
+
+        # Parameters.
+        # Note: torch.nn.functional.linear performs XA^T + b and as a result
+        # we allocate the transpose.
+        self.weight = Parameter(torch.empty((self.out_features, self.input_size_per_partition), dtype=torch.int8), requires_grad=False)
+        self.weight_scaler = Parameter(torch.empty(1), requires_grad=False)
+        if bias:
+            self.bias = Parameter(torch.Tensor(self.out_features))
+            # Always initialize bias to zero.
+            with torch.no_grad():
+                self.bias.zero_()
+        else:
+            self.register_parameter("bias", None)
+
+        # Initialize weight.
+        self.master_weight = _initialize_affine_weight(
+            self.weight,
+            self.out_features,
+            self.in_features,
+            self.input_size_per_partition,
+            1,
+            init_method,
+            stride=stride,
+            return_master_weight=keep_master_weight_for_test,
+        )
+        self.groups = get_model_parallel_group()
+        self.world_size = get_model_parallel_world_size()
+        self.rank = get_model_parallel_rank()
+
+    def get_master_weight(self) -> torch.Tensor:
+        return gather_from_model_parallel_region(self.weight.data, self.groups, self.world_size, self.rank)
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:  # type:ignore
+        # Set up backprop all-reduce.
+        if self.input_is_parallel:
+            input_parallel = input_
+        else:
+            input_parallel = scatter_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
+        # Matrix multiply.
+        fp_w = self.weight * self.weight_scaler
+        # output_parallel = F.linear(input_parallel, self.weight, self.bias)
+        output_parallel = F.linear(input_parallel, fp_w, self.bias)
         # All-reduce across all the partitions.
         output_ = reduce_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
         if self.bias is not None:

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -316,7 +316,7 @@ class ColumnParallelLinear(torch.nn.Module):
         # we allocate the transpose.
         if quant:
             self.weight = Parameter(torch.empty((self.output_size_per_partition, self.in_features), dtype=torch.int8), requires_grad=False)
-            self.weight_scaler = Parameter(torch.empty(1), requires_grad=False)
+            self.weight_scaler = Parameter(torch.zeros(1), requires_grad=False)
         else:
             self.weight = Parameter(torch.Tensor(self.output_size_per_partition, self.in_features))
         if bias:
@@ -426,7 +426,7 @@ class RowParallelLinear(torch.nn.Module):
         # we allocate the transpose.
         if quant:
             self.weight = Parameter(torch.empty((self.out_features, self.input_size_per_partition), dtype=torch.int8), requires_grad=False)
-            self.weight_scaler = Parameter(torch.empty(1), requires_grad=False)
+            self.weight_scaler = Parameter(torch.zeros(1), requires_grad=False)
         else:
             self.weight = Parameter(torch.Tensor(self.out_features, self.input_size_per_partition))
         if bias:

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -427,9 +427,9 @@ class ColumnParallelLinearQuant(torch.nn.Module):
         # Set up backprop all-reduce.
         input_parallel = copy_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
         # Matrix multiply.
-        fp_w = self.weight * self.weight_scaler
         # output_parallel = F.linear(input_parallel, self.weight, self.bias)
-        output_parallel = F.linear(input_parallel, fp_w, self.bias)
+        output_parallel = F.linear(input_parallel, self.weight, self.bias)
+        output_parallel = output_parallel * self.weight_scaler
         if self.gather_output:
             # All-gather across the partitions.
             output = gather_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
@@ -625,9 +625,9 @@ class RowParallelLinearQuant(torch.nn.Module):
         else:
             input_parallel = scatter_to_model_parallel_region(input_, self.groups, self.world_size, self.rank)
         # Matrix multiply.
-        fp_w = self.weight * self.weight_scaler
         # output_parallel = F.linear(input_parallel, self.weight, self.bias)
-        output_parallel = F.linear(input_parallel, fp_w, self.bias)
+        output_parallel = F.linear(input_parallel, self.weight, self.bias)
+        output_parallel = output_parallel * self.weight_scaler
         # All-reduce across all the partitions.
         output_ = reduce_from_model_parallel_region(output_parallel, self.groups, self.world_size, self.rank)
         if self.bias is not None:

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -360,6 +360,7 @@ class ColumnParallelLinear(torch.nn.Module):
             output = output_parallel
         return output
 
+
 class RowParallelLinear(torch.nn.Module):
     """Linear layer with row parallelism.
 


### PR DESCRIPTION
- Add int8 weight-only Quantized Linear Layer
   Quantization is symmetric quantization, weights are stored in int8 containers, scaler is used for decoding int8 weights.
   I kept the quantized layers to be in separated classes for now, to keep the bf16 and quant workflow completely separate. As quantized flow is quite experimental for now. cc @wonjoolee95 
- Add `quant` flag to enable Quantized Linear Layer
- Rewrite the rotary embedding to avoid generating tensor with 1 more axis, which would potentially cause XLA to generate a less efficient graph.
  In function `apply_rotary_emb `, `freqs_cis` always has shape of `[1, dim // n_heads / 2]`, so the call to `reshape_for_broadcast` can be removed.
  Changing `xq.float().reshape(*xq.shape[:-1], -1, 2)` to `xq.float().reshape(-1, int(xq.shape[-1]/2), 2)` will flatten the higher dimensions and those higher dimensions will be broadcasted in `xq_ * freqs_cis` and `xk_ * freqs_cis`. So the change here should be safe. The shape is recovered before returning the result.