### PR TITLE
Enable CUDA eager and inductor

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Different models have different original_mp values:
 | 33B    | 4           |
 | 65B    | 8           |
 
+### XLA GPU
+
+`example_xla.py` can also be ran on GPUs with XLA:GPU.
+```
+PJRT_DEVICE=GPU GPU_NUM_DEVICES=4 python3 example_xla.py --tokenizer_path $TOKENIZER_PATH --max_seq_len 256 --max_batch_size 1 --temperature 0.8 --dim 4096 --n_heads 32 --n_layers 32 --mp True
+```
+
 ## CUDA
 
 `example_cuda.py` is provided to produce CUDA (using Inductor by default) results as the same format as `example_xla.py` such that one can easily compare

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LLaMA 
+# LLaMA
 
 This repository is intended as a minimal, hackable and readable example to load [LLaMA](https://ai.facebook.com/blog/large-language-model-llama-meta-ai/) ([arXiv](https://arxiv.org/abs/2302.13971v1)) models and run inference.
 In order to download the checkpoints and tokenizer, fill this [google form](https://forms.gle/jk851eBVbX1m5TAv5)
@@ -81,6 +81,16 @@ Different models have different original_mp values:
 | 13B    | 2           |
 | 33B    | 4           |
 | 65B    | 8           |
+
+## CUDA
+
+`example_cuda.py` is provided to produce CUDA (using Inductor by default) results as the same format as `example_xla.py` such that one can easily compare
+results among XLA:TPU, XLA:GPU, CUDA eager, CUDA Inductor.
+
+Here is how you can use it:
+```
+USE_CUDA=1 python3 example_cuda.py --tokenizer_path $TOKENIZER_PATH --max_seq_len 256 --max_batch_size 1 --temperature 0.8 --dim 4096 --n_heads 32 --n_layers 32 --mp True
+```
 
 ## FAQ
 

--- a/example.py
+++ b/example.py
@@ -48,9 +48,9 @@ def load(
     with open(Path(ckpt_dir) / "params.json", "r") as f:
         params = json.loads(f.read())
 
-    model_args: ModelArgs = ModelArgs(
-        max_seq_len=max_seq_len, max_batch_size=max_batch_size, **params
-    )
+    model_args: ModelArgs = ModelArgs(max_seq_len=max_seq_len,
+                                      max_batch_size=max_batch_size,
+                                      **params)
     tokenizer = Tokenizer(model_path=tokenizer_path)
     model_args.vocab_size = tokenizer.n_words
     torch.set_default_tensor_type(torch.cuda.HalfTensor)
@@ -75,9 +75,8 @@ def main(
     if local_rank > 0:
         sys.stdout = open(os.devnull, "w")
 
-    generator = load(
-        ckpt_dir, tokenizer_path, local_rank, world_size, max_seq_len, max_batch_size
-    )
+    generator = load(ckpt_dir, tokenizer_path, local_rank, world_size,
+                     max_seq_len, max_batch_size)
 
     prompts = [
         # For these prompts, the expected answer is the natural continuation of the prompt
@@ -106,9 +105,10 @@ plush girafe => girafe peluche
 
 cheese =>""",
     ]
-    results = generator.generate(
-        prompts, max_gen_len=256, temperature=temperature, top_p=top_p
-    )
+    results = generator.generate(prompts,
+                                 max_gen_len=256,
+                                 temperature=temperature,
+                                 top_p=top_p)
 
     for result in results:
         print(result)

--- a/example_cuda.py
+++ b/example_cuda.py
@@ -1,0 +1,125 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This software may be used and distributed according to the terms of the GNU General Public License version 3.
+
+from typing import Tuple
+import os
+import sys
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as xmp
+import fire
+
+from llama.xla_model_parallel import set_g_group
+from example_xla import load
+
+def setup_model_parallel(rank, world_size) -> Tuple[int, int]:
+    # assuming model parallelism over the whole world size
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '12356'
+
+    # initialize the process group
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    set_g_group()
+
+    # seed must be the same in all processes
+    torch.manual_seed(1)
+
+def main(
+    rank: int,
+    world_size: int,
+    tokenizer_path: str,
+    temperature: float = 0.8,
+    top_p: float = 0.95,
+    max_seq_len: int = 512,
+    max_batch_size: int = 32,
+    ckpt_dir: str = '',
+    dim: int = 4096,
+    n_layers: int = 32,
+    n_heads: int = 32,
+):
+    print(ckpt_dir)
+    setup_model_parallel(rank, world_size)
+    if rank > 0:
+        sys.stdout = open(os.devnull, "w")
+
+    generator = load(
+        ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, torch.device("cuda", rank), dim, n_layers, n_heads
+    )
+
+    prompts = [
+        # For these prompts, the expected answer is the natural continuation of the prompt
+        "I believe the meaning of life is",
+        # "Simply put, the theory of relativity states that ",
+        # "Building a website can be done in 10 simple steps:\n",
+        # Few shot prompts: https://huggingface.co/blog/few-shot-learning-gpt-neo-and-inference-api
+#        """Tweet: "I hate it when my phone battery dies."
+#Sentiment: Negative
+####
+#Tweet: "My day has been 👍"
+#Sentiment: Positive
+####
+#Tweet: "This is the link to the article"
+#Sentiment: Neutral
+####
+#Tweet: "This new music video was incredibile"
+#Sentiment:""",
+#        """Translate English to French:
+#
+#sea otter => loutre de mer
+#
+#peppermint => menthe poivrée
+#
+#plush girafe => girafe peluche
+#
+#cheese =>""",
+    ]
+    for _ in range(2):
+        with torch.no_grad():
+            results = generator.generate(
+                prompts, 256, torch.device("cuda", rank), temperature=temperature, top_p=top_p
+            )
+
+        for result in results:
+            print(result)
+            print("\n==================================\n")
+
+
+def _fn(
+    rank: int,
+    world_size: int,
+    tokenizer_path: str,
+    temperature: float = 0.8,
+    top_p: float = 0.95,
+    max_seq_len: int = 512,
+    max_batch_size: int = 32,
+    ckpt_dir: str = '',
+    dim: int = 4096,
+    n_layers: int = 32,
+    n_heads: int = 32,
+):
+    main(rank, world_size, tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads)
+
+def mp_main(
+    mp: bool,
+    tokenizer_path: str,
+    temperature: float = 0.8,
+    top_p: float = 0.95,
+    max_seq_len: int = 512,
+    max_batch_size: int = 32,
+    ckpt_dir: str = '',
+    dim: int = 4096,
+    n_layers: int = 32,
+    n_heads: int = 32,
+):
+    world_size = 1
+    assert torch.cuda.is_available(), "cuda is not available"
+    if mp:
+        world_size = torch.cuda.device_count()
+        print(f"Spawning {world_size} processes")
+        xmp.spawn(_fn, args=(world_size, tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads), nprocs=world_size, join=True)
+    else:
+        main(0, world_size, tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads)
+
+
+if __name__ == "__main__":
+    fire.Fire(mp_main)

--- a/example_xla.py
+++ b/example_xla.py
@@ -71,7 +71,7 @@ def load(
     )
     tokenizer = Tokenizer(model_path=tokenizer_path)
     model_args.vocab_size = tokenizer.n_words
-    # torch.set_default_tensor_type(torch.BFloat16Tensor)
+    torch.set_default_tensor_type(torch.BFloat16Tensor)
     model = Transformer(model_args)
     if ckpt_dir:
         model.load_state_dict(checkpoint, strict=False)

--- a/example_xla.py
+++ b/example_xla.py
@@ -60,18 +60,19 @@ def load(
         with open(Path(ckpt_dir) / "params.json", "r") as f:
             params = json.loads(f.read())
     else:
-        params = {"dim": dim,
-                  "n_layers": n_layers,
-                  "n_heads": n_heads,
-                  "quant": quant,
-                  }
+        params = {
+            "dim": dim,
+            "n_layers": n_layers,
+            "n_heads": n_heads,
+            "quant": quant,
+        }
 
-    model_args: ModelArgs = ModelArgs(
-        max_seq_len=max_seq_len, max_batch_size=max_batch_size, **params
-    )
+    model_args: ModelArgs = ModelArgs(max_seq_len=max_seq_len,
+                                      max_batch_size=max_batch_size,
+                                      **params)
     tokenizer = Tokenizer(model_path=tokenizer_path)
     model_args.vocab_size = tokenizer.n_words
-    torch.set_default_tensor_type(torch.BFloat16Tensor)
+    # torch.set_default_tensor_type(torch.BFloat16Tensor)
     model = Transformer(model_args)
     if ckpt_dir:
         model.load_state_dict(checkpoint, strict=False)
@@ -101,9 +102,9 @@ def main(
     if rank > 0:
         sys.stdout = open(os.devnull, "w")
 
-    generator = load(
-        ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, xm.xla_device(), dim, n_layers, n_heads, quant
-    )
+    generator = load(ckpt_dir, tokenizer_path,
+                     rank, world_size, max_seq_len, max_batch_size,
+                     xm.xla_device(), dim, n_layers, n_heads, quant)
 
     prompts = [
         # For these prompts, the expected answer is the natural continuation of the prompt
@@ -158,7 +159,9 @@ def _fn(
     n_heads: int = 32,
     quant: bool = False,
 ):
-    main(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads, quant)
+    main(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size,
+         ckpt_dir, dim, n_layers, n_heads, quant)
+
 
 def mp_main(
     mp: bool,
@@ -174,9 +177,13 @@ def mp_main(
     quant: bool = False,
 ):
     if mp:
-        xmp.spawn(_fn, args=(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads, quant))
+        xmp.spawn(_fn,
+                  args=(tokenizer_path, temperature, top_p, max_seq_len,
+                        max_batch_size, ckpt_dir, dim, n_layers, n_heads,
+                        quant))
     else:
-        main(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size, ckpt_dir, dim, n_layers, n_heads, quant)
+        main(tokenizer_path, temperature, top_p, max_seq_len, max_batch_size,
+             ckpt_dir, dim, n_layers, n_heads, quant)
 
 
 if __name__ == "__main__":

--- a/example_xla.py
+++ b/example_xla.py
@@ -14,6 +14,7 @@ from llama import ModelArgs, Transformer, Tokenizer, LLaMA
 from llama.xla_model_parallel import get_model_parallel_rank, get_model_parallel_world_size
 
 import os
+
 USE_CUDA = os.environ.get('USE_CUDA', False)
 
 if not USE_CUDA:
@@ -110,32 +111,33 @@ def main(
         # "Simply put, the theory of relativity states that ",
         # "Building a website can be done in 10 simple steps:\n",
         # Few shot prompts: https://huggingface.co/blog/few-shot-learning-gpt-neo-and-inference-api
-#        """Tweet: "I hate it when my phone battery dies."
-#Sentiment: Negative
-####
-#Tweet: "My day has been 👍"
-#Sentiment: Positive
-####
-#Tweet: "This is the link to the article"
-#Sentiment: Neutral
-####
-#Tweet: "This new music video was incredibile"
-#Sentiment:""",
-#        """Translate English to French:
-#
-#sea otter => loutre de mer
-#
-#peppermint => menthe poivrée
-#
-#plush girafe => girafe peluche
-#
-#cheese =>""",
+        #        """Tweet: "I hate it when my phone battery dies."
+        #Sentiment: Negative
+        ####
+        #Tweet: "My day has been 👍"
+        #Sentiment: Positive
+        ####
+        #Tweet: "This is the link to the article"
+        #Sentiment: Neutral
+        ####
+        #Tweet: "This new music video was incredibile"
+        #Sentiment:""",
+        #        """Translate English to French:
+        #
+        #sea otter => loutre de mer
+        #
+        #peppermint => menthe poivrée
+        #
+        #plush girafe => girafe peluche
+        #
+        #cheese =>""",
     ]
     for _ in range(2):
         with torch.no_grad():
-            results = generator.generate(
-                prompts, max_gen_len=256, temperature=temperature, top_p=top_p
-            )
+            results = generator.generate(prompts,
+                                         max_gen_len=256,
+                                         temperature=temperature,
+                                         top_p=top_p)
 
         for result in results:
             print(result)

--- a/example_xla.py
+++ b/example_xla.py
@@ -135,7 +135,8 @@ def main(
     for _ in range(2):
         with torch.no_grad():
             results = generator.generate(prompts,
-                                         max_gen_len=256,
+                                         256,
+                                         xm.xla_device(),
                                          temperature=temperature,
                                          top_p=top_p)
 

--- a/example_xla.py
+++ b/example_xla.py
@@ -17,6 +17,7 @@ import os
 
 USE_CUDA = os.environ.get('USE_CUDA', False)
 
+# Some how xla init will slow down the CUDA speed.
 if not USE_CUDA:
     import torch_xla.core.xla_model as xm
     import torch_xla.distributed.xla_multiprocessing as xmp

--- a/example_xla.py
+++ b/example_xla.py
@@ -72,7 +72,7 @@ def load(
                                       **params)
     tokenizer = Tokenizer(model_path=tokenizer_path)
     model_args.vocab_size = tokenizer.n_words
-    # torch.set_default_tensor_type(torch.BFloat16Tensor)
+    torch.set_default_tensor_type(torch.BFloat16Tensor)
     model = Transformer(model_args)
     if ckpt_dir:
         model.load_state_dict(checkpoint, strict=False)

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -5,22 +5,27 @@ import time
 from typing import List
 
 import torch
-import torch_xla.core.xla_model as xm
 
 from llama.tokenizer import Tokenizer
 from llama.model import Transformer
 
+import os
+USE_CUDA = os.environ.get('USE_CUDA', False)
+
+if not USE_CUDA:
+    import torch_xla.core.xla_model as xm
 
 class LLaMA:
     def __init__(self, model: Transformer, tokenizer: Tokenizer):
         self.model = model
         self.tokenizer = tokenizer
         self._generate_one_token_fn = self._generate_one_token
-        self._generate_one_token_fn = torch.compile(self._generate_one_token_fn,
-                                                    backend="torchxla_trace_once", fullgraph=True)
+        # self._generate_one_token_fn = torch.compile(self._generate_one_token_fn,
+        #                                             backend="torchxla_trace_once", fullgraph=True)
 
-    def _generate_one_token(self, tokens, input_tokens, input_text_mask, cur_pos_tensor, 
+    def _generate_one_token(self, tokens, input_tokens, input_text_mask, cur_pos_tensor,
                             input_pos_tensor, output_pos_tensor, cache_kvs, temperature, top_p):
+        print(input_tokens)
         logits, cache_kvs = self.model(input_tokens, input_pos_tensor, output_pos_tensor, cache_kvs)
         if temperature > 0:
             probs = torch.softmax(logits / temperature, dim=-1)
@@ -47,6 +52,7 @@ class LLaMA:
         self,
         prompts: List[str],
         max_gen_len: int,
+        device: torch.device,
         temperature: float = 0.8,
         top_p: float = 0.95,
     ) -> List[str]:
@@ -56,14 +62,13 @@ class LLaMA:
         params = self.model.params
         assert bsz <= params.max_batch_size, (bsz, params.max_batch_size)
 
-        prompt_tokens = [self.tokenizer.encode(x, bos=True, eos=False) for x in prompts]
+        prompt_tokens = [self.tokenizer.encode(x, bos=False, eos=False) for x in prompts]
 
         total_len = params.max_seq_len
 
         tokens = torch.full((params.max_batch_size, total_len), self.tokenizer.pad_id).long()
         for k, t in enumerate(prompt_tokens):
             tokens[k, : len(t)] = torch.tensor(t).long()
-        device = xm.xla_device()
         tokens = tokens.to(device)
         input_text_mask = tokens != self.tokenizer.pad_id
 
@@ -73,7 +78,8 @@ class LLaMA:
         output_pos_tensor = cur_pos_tensor - 1
         input_tokens = tokens.index_select(1, input_pos_tensor)
         cache_kvs = self.model.cache_kvs
-        xm.mark_step(wait=True)
+        if device.type == "xla":
+            xm.mark_step(wait=True)
 
         decoding_start_time = time.time()
         for _ in range(start_pos, total_len):
@@ -82,7 +88,8 @@ class LLaMA:
                     tokens, input_tokens, input_text_mask, cur_pos_tensor,
                     input_pos_tensor, output_pos_tensor, cache_kvs, temperature, top_p
                 )
-            xm.mark_step()
+            if device.type == "xla":
+                xm.mark_step()
         self.model.cache_kvs = cache_kvs
         print(f"Decoded in {time.time() - decoding_start_time:.5f} seconds")
 

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -25,7 +25,6 @@ class LLaMA:
 
     def _generate_one_token(self, tokens, input_tokens, input_text_mask, cur_pos_tensor,
                             input_pos_tensor, output_pos_tensor, cache_kvs, temperature, top_p):
-        print(input_tokens)
         logits, cache_kvs = self.model(input_tokens, input_pos_tensor, output_pos_tensor, cache_kvs)
         if temperature > 0:
             probs = torch.softmax(logits / temperature, dim=-1)
@@ -62,7 +61,8 @@ class LLaMA:
         params = self.model.params
         assert bsz <= params.max_batch_size, (bsz, params.max_batch_size)
 
-        prompt_tokens = [self.tokenizer.encode(x, bos=False, eos=False) for x in prompts]
+        bos = not USE_CUDA  # The supplied t5 tokenizer doesn't have bos. CUDA will error out but xla won't.
+        prompt_tokens = [self.tokenizer.encode(x, bos=bos, eos=False) for x in prompts]
 
         total_len = params.max_seq_len
 

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -13,6 +13,7 @@ import os
 
 USE_CUDA = os.environ.get('USE_CUDA', False)
 
+# Some how xla init will slow down the CUDA speed.
 if not USE_CUDA:
     import torch_xla.core.xla_model as xm
 

--- a/llama/model.py
+++ b/llama/model.py
@@ -36,6 +36,7 @@ class ModelArgs:
 
 
 class RMSNorm(torch.nn.Module):
+
     def __init__(self, dim: int, eps: float = 1e-6):
         super().__init__()
         self.eps = eps
@@ -50,7 +51,7 @@ class RMSNorm(torch.nn.Module):
 
 
 def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0):
-    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    freqs = 1.0 / (theta**(torch.arange(0, dim, 2)[:(dim // 2)].float() / dim))
     t = torch.arange(end, device=freqs.device)  # type: ignore
     freqs = torch.outer(t, freqs).float()  # type: ignore
     freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
@@ -61,7 +62,9 @@ def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
     ndim = x.ndim
     assert 0 <= 1 < ndim
     assert freqs_cis.shape == (x.shape[1], x.shape[-1])
-    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
+    shape = [
+        d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)
+    ]
     return freqs_cis.view(*shape)
 
 
@@ -80,8 +83,12 @@ def apply_rotary_emb(
 
 
 class Attention(nn.Module):
-    def __init__(self, args: ModelArgs, world_size: Optional[int] = None,
-                 rank: Optional[int] = None, groups: Optional[List] = None):
+
+    def __init__(self,
+                 args: ModelArgs,
+                 world_size: Optional[int] = None,
+                 rank: Optional[int] = None,
+                 groups: Optional[List] = None):
         super().__init__()
 
         if world_size is None:
@@ -89,7 +96,8 @@ class Attention(nn.Module):
             world_size = get_model_parallel_world_size()
             rank = get_model_parallel_rank()
 
-        self.n_local_heads = divide_and_check_no_remainder(args.n_heads, world_size)
+        self.n_local_heads = divide_and_check_no_remainder(
+            args.n_heads, world_size)
         self.head_dim = args.dim // args.n_heads
 
         init_method = lambda x: x
@@ -161,18 +169,19 @@ class Attention(nn.Module):
         xq = xq.transpose(1, 2)
         keys = keys.transpose(1, 2)
         values = values.transpose(1, 2)
-        scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
+        scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(
+            self.head_dim)
         scores = scores + mask  # (bs, n_local_heads, slen, max_slen)
         scores = F.softmax(scores.float(), dim=-1).type_as(xq)
-        output = torch.matmul(scores, values)  # (bs, n_local_heads, slen, head_dim)
-        output = output.transpose(
-            1, 2
-        ).contiguous().view(bsz, seqlen, -1)
+        output = torch.matmul(scores,
+                              values)  # (bs, n_local_heads, slen, head_dim)
+        output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
 
         return self.wo(output), (cache_k, cache_v)
 
 
 class FeedForward(nn.Module):
+
     def __init__(
         self,
         dim: int,
@@ -185,7 +194,8 @@ class FeedForward(nn.Module):
     ):
         super().__init__()
         hidden_dim = int(2 * hidden_dim / 3)
-        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+        hidden_dim = multiple_of * (
+            (hidden_dim + multiple_of - 1) // multiple_of)
 
         if world_size is None:
             groups = get_model_parallel_group()
@@ -212,8 +222,13 @@ class FeedForward(nn.Module):
 
 
 class TransformerBlock(nn.Module):
-    def __init__(self, layer_id: int, args: ModelArgs, world_size: Optional[int] = None,
-                 rank: Optional[int] = None, groups: Optional[List] = None):
+
+    def __init__(self,
+                 layer_id: int,
+                 args: ModelArgs,
+                 world_size: Optional[int] = None,
+                 rank: Optional[int] = None,
+                 groups: Optional[List] = None):
         super().__init__()
         self.n_heads = args.n_heads
         self.dim = args.dim
@@ -234,19 +249,24 @@ class TransformerBlock(nn.Module):
         self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
         self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
 
-    def forward(self, x: torch.Tensor, freqs_cis: torch.Tensor, mask: Optional[torch.Tensor],
-                input_idexes: torch.Tensor, cache_kv: Tuple[torch.Tensor, torch.Tensor]):
-        h, new_cache_kv = self.attention.forward(
-            self.attention_norm(x), freqs_cis, mask, input_idexes, cache_kv
-        )
+    def forward(self, x: torch.Tensor, freqs_cis: torch.Tensor,
+                mask: Optional[torch.Tensor], input_idexes: torch.Tensor,
+                cache_kv: Tuple[torch.Tensor, torch.Tensor]):
+        h, new_cache_kv = self.attention.forward(self.attention_norm(x),
+                                                 freqs_cis, mask, input_idexes,
+                                                 cache_kv)
         h = x + h
         out = h + self.feed_forward.forward(self.ffn_norm(h))
         return out, new_cache_kv
 
 
 class Transformer(nn.Module):
-    def __init__(self, params: ModelArgs, world_size: Optional[int] = None,
-                 rank: Optional[int] = None, groups: Optional[List] = None):
+
+    def __init__(self,
+                 params: ModelArgs,
+                 world_size: Optional[int] = None,
+                 rank: Optional[int] = None,
+                 groups: Optional[List] = None):
         super().__init__()
         self.params = params
         self.vocab_size = params.vocab_size
@@ -259,24 +279,29 @@ class Transformer(nn.Module):
 
         init_method = lambda x: x
 
-        self.tok_embeddings = ParallelEmbedding(
-            params.vocab_size, params.dim, init_method=init_method,
-            world_size=world_size, rank=rank, groups=groups
-        )
+        self.tok_embeddings = ParallelEmbedding(params.vocab_size,
+                                                params.dim,
+                                                init_method=init_method,
+                                                world_size=world_size,
+                                                rank=rank,
+                                                groups=groups)
 
         self.layers = torch.nn.ModuleList()
         self.cache_kvs = []
-        n_local_heads = divide_and_check_no_remainder(params.n_heads, world_size)
+        n_local_heads = divide_and_check_no_remainder(params.n_heads,
+                                                      world_size)
         head_dim = params.dim // params.n_heads
         for layer_id in range(params.n_layers):
-            self.layers.append(TransformerBlock(layer_id, params, world_size=world_size,
-                                                rank=rank, groups=groups))
-            cache_k = torch.zeros(
-                (params.max_batch_size, params.max_seq_len, n_local_heads, head_dim)
-            )
-            cache_v = torch.zeros(
-                (params.max_batch_size, params.max_seq_len, n_local_heads, head_dim)
-            )
+            self.layers.append(
+                TransformerBlock(layer_id,
+                                 params,
+                                 world_size=world_size,
+                                 rank=rank,
+                                 groups=groups))
+            cache_k = torch.zeros((params.max_batch_size, params.max_seq_len,
+                                   n_local_heads, head_dim))
+            cache_v = torch.zeros((params.max_batch_size, params.max_seq_len,
+                                   n_local_heads, head_dim))
             self.cache_kvs.append((cache_k, cache_v))
 
         self.norm = RMSNorm(params.dim, eps=params.norm_eps)
@@ -286,17 +311,19 @@ class Transformer(nn.Module):
         )
 
         freqs_cis = precompute_freqs_cis(
-            self.params.dim // self.params.n_heads, self.params.max_seq_len * 2
-        )
+            self.params.dim // self.params.n_heads,
+            self.params.max_seq_len * 2)
         self.register_buffer("freqs_cis", freqs_cis)
 
-        mask = torch.full((1, 1, self.params.max_seq_len, self.params.max_seq_len),
-                          float("-inf")).to(torch.float)
+        mask = torch.full(
+            (1, 1, self.params.max_seq_len, self.params.max_seq_len),
+            float("-inf")).to(torch.float)
         mask = torch.triu(mask, diagonal=1)
         self.register_buffer("mask", mask)
 
     @torch.no_grad()
-    def forward(self, tokens: torch.Tensor, input_idexes: torch.Tensor, output_idex: torch.Tensor,
+    def forward(self, tokens: torch.Tensor, input_idexes: torch.Tensor,
+                output_idex: torch.Tensor,
                 cache_kvs: List[Tuple[torch.Tensor, torch.Tensor]]):
         bsz, seqlen = tokens.shape
         assert bsz == self.params.max_batch_size

--- a/llama/model.py
+++ b/llama/model.py
@@ -95,7 +95,6 @@ class Attention(nn.Module):
 
         init_method = lambda x: x
 
-        print(args.dim, args.n_heads * self.head_dim)
         self.wq = nn.Linear(
             args.dim,
             args.n_heads * self.head_dim,
@@ -144,9 +143,7 @@ class Attention(nn.Module):
 
     def forward(self, x: torch.Tensor, freqs_cis: torch.Tensor, mask: Optional[torch.Tensor],
                 input_idexes: torch.Tensor, cache_kv: Tuple[torch.Tensor, torch.Tensor]):
-        print(x.shape)
         bsz, seqlen, _ = x.shape
-        print(bsz, seqlen, _)
         cache_k, cache_v = cache_kv
         xq = self.wq(x)
         xk = self.wk(x)

--- a/llama/model.py
+++ b/llama/model.py
@@ -11,14 +11,14 @@ import torch.nn.functional as F
 
 from fairscale.nn.model_parallel.utils import divide_and_check_no_remainder
 
-from .xla_model_parallel import (
-    ParallelEmbedding,
-    RowParallelLinear,
-    ColumnParallelLinear,
-    get_model_parallel_group,
-    get_model_parallel_world_size,
-    get_model_parallel_rank,
-)
+# from .xla_model_parallel import (
+#     nn.Embedding,
+#     nn.Linear,
+#     nn.Linear,
+#     get_model_parallel_group,
+#     get_model_parallel_world_size,
+#     get_model_parallel_rank,
+# )
 
 
 @dataclass
@@ -84,17 +84,19 @@ class Attention(nn.Module):
                  rank: Optional[int] = None, groups: Optional[List] = None):
         super().__init__()
 
-        if world_size is None:
-            groups = get_model_parallel_group()
-            world_size = get_model_parallel_world_size()
-            rank = get_model_parallel_rank()
+        # if world_size is None:
+        #     groups = get_model_parallel_group()
+        #     world_size = get_model_parallel_world_size()
+        #     rank = get_model_parallel_rank()
 
-        self.n_local_heads = divide_and_check_no_remainder(args.n_heads, world_size)
+        # self.n_local_heads = divide_and_check_no_remainder(args.n_heads, world_size)
+        self.n_local_heads = args.n_heads
         self.head_dim = args.dim // args.n_heads
 
         init_method = lambda x: x
 
-        self.wq = ColumnParallelLinear(
+        print(args.dim, args.n_heads * self.head_dim)
+        self.wq = nn.Linear(
             args.dim,
             args.n_heads * self.head_dim,
             bias=False,
@@ -105,7 +107,7 @@ class Attention(nn.Module):
             groups=groups,
             quant=args.quant,
         )
-        self.wk = ColumnParallelLinear(
+        self.wk = nn.Linear(
             args.dim,
             args.n_heads * self.head_dim,
             bias=False,
@@ -116,7 +118,7 @@ class Attention(nn.Module):
             groups=groups,
             quant=args.quant,
         )
-        self.wv = ColumnParallelLinear(
+        self.wv = nn.Linear(
             args.dim,
             args.n_heads * self.head_dim,
             bias=False,
@@ -127,7 +129,7 @@ class Attention(nn.Module):
             groups=groups,
             quant=args.quant,
         )
-        self.wo = RowParallelLinear(
+        self.wo = nn.Linear(
             args.n_heads * self.head_dim,
             args.dim,
             bias=False,
@@ -138,13 +140,17 @@ class Attention(nn.Module):
             groups=groups,
             quant=args.quant,
         )
-            
+
 
     def forward(self, x: torch.Tensor, freqs_cis: torch.Tensor, mask: Optional[torch.Tensor],
                 input_idexes: torch.Tensor, cache_kv: Tuple[torch.Tensor, torch.Tensor]):
+        print(x.shape)
         bsz, seqlen, _ = x.shape
+        print(bsz, seqlen, _)
         cache_k, cache_v = cache_kv
-        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+        xq = self.wq(x)
+        xk = self.wk(x)
+        xv = self.wv(x)
 
         xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
         xk = xk.view(bsz, seqlen, self.n_local_heads, self.head_dim)
@@ -187,10 +193,10 @@ class FeedForward(nn.Module):
         hidden_dim = int(2 * hidden_dim / 3)
         hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-        if world_size is None:
-            groups = get_model_parallel_group()
-            world_size = get_model_parallel_world_size()
-            rank = get_model_parallel_rank()
+        # if world_size is None:
+        #     groups = get_model_parallel_group()
+        #     world_size = get_model_parallel_world_size()
+        #     rank = get_model_parallel_rank()
 
         init_method = lambda x: x
 
@@ -216,13 +222,14 @@ class TransformerBlock(nn.Module):
         self.dim = args.dim
         self.head_dim = args.dim // args.n_heads
 
-        if world_size is None:
-            groups = get_model_parallel_group()
-            world_size = get_model_parallel_world_size()
-            rank = get_model_parallel_rank()
+        # if world_size is None:
+        #     groups = get_model_parallel_group()
+        #     world_size = get_model_parallel_world_size()
+        #     rank = get_model_parallel_rank()
 
-        self.attention = Attention(args, world_size=world_size,
-                                   rank=rank, groups=groups)
+        self.attention = Attention(args,
+                                #    world_size=world_size, rank=rank, groups=groups
+                                   )
         self.feed_forward = FeedForward(
             dim=args.dim, hidden_dim=4 * args.dim, multiple_of=args.multiple_of,
             world_size=world_size, rank=rank, groups=groups, quant=args.quant
@@ -249,21 +256,22 @@ class Transformer(nn.Module):
         self.vocab_size = params.vocab_size
         self.n_layers = params.n_layers
 
-        if world_size is None:
-            groups = get_model_parallel_group()
-            world_size = get_model_parallel_world_size()
-            rank = get_model_parallel_rank()
+        # if world_size is None:
+        #     groups = get_model_parallel_group()
+        #     world_size = get_model_parallel_world_size()
+        #     rank = get_model_parallel_rank()
 
         init_method = lambda x: x
 
-        self.tok_embeddings = ParallelEmbedding(
-            params.vocab_size, params.dim, init_method=init_method,
-            world_size=world_size, rank=rank, groups=groups
+        self.tok_embeddings = nn.Embedding(
+            params.vocab_size, params.dim,
+            # init_method=init_method, world_size=world_size, rank=rank, groups=groups
         )
 
         self.layers = torch.nn.ModuleList()
         self.cache_kvs = []
-        n_local_heads = divide_and_check_no_remainder(params.n_heads, world_size)
+        # n_local_heads = divide_and_check_no_remainder(params.n_heads, world_size)
+        n_local_heads = params.n_heads
         head_dim = params.dim // params.n_heads
         for layer_id in range(params.n_layers):
             self.layers.append(TransformerBlock(layer_id, params, world_size=world_size,

--- a/llama/tokenizer.py
+++ b/llama/tokenizer.py
@@ -6,11 +6,11 @@ from logging import getLogger
 from typing import List
 import os
 
-
 logger = getLogger()
 
 
 class Tokenizer:
+
     def __init__(self, model_path: str):
         # reload tokenizer
         assert os.path.isfile(model_path), model_path

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -124,7 +124,6 @@ def gather_from_model_parallel_region(input_: torch.Tensor, groups, world_size, 
 def my_reduce(input_: torch.Tensor, groups, world_size, rank) -> torch.Tensor:
     """All-reduce the the input tensor across model parallel group."""
     # Bypass the function if we are using only 1 GPU.
-    print(world_size)
     if world_size == 1:
         return input_
 
@@ -156,7 +155,6 @@ def my_split(input_: torch.Tensor, groups, world_size, rank) -> torch.Tensor:
 def my_gather(input_: torch.Tensor, groups, world_size, rank) -> torch.Tensor:
     """Gather tensors and concatinate along the last dimension."""
     # Bypass the function if we are using only 1 GPU.
-    print(world_size)
     if world_size == 1:
         return input_
 
@@ -187,8 +185,6 @@ def _initialize_affine_weight(
 
     Build the master weight on all processes and scatter
     the relevant chunk."""
-
-    print("init", world_size, rank)
 
     # If we only use 1 process for model parallelism, bypass scatter.
     if world_size == 1:
@@ -240,8 +236,6 @@ class ParallelEmbedding(torch.nn.Module):
         groups: Optional[List] = None,
     ) -> None:
         super(ParallelEmbedding, self).__init__()
-
-        print("init", world_size, groups, rank)
 
         if world_size is None:
             self.groups = get_model_parallel_group()
@@ -331,8 +325,6 @@ class ColumnParallelLinear(torch.nn.Module):
         quant: bool = False,
     ) -> None:
         super(ColumnParallelLinear, self).__init__()
-
-        print("init", world_size, groups, rank)
 
         if world_size is None:
             self.groups = get_model_parallel_group()
@@ -443,8 +435,6 @@ class RowParallelLinear(torch.nn.Module):
         quant: bool = False,
     ):
         super(RowParallelLinear, self).__init__()
-
-        print("init", world_size, groups, rank)
 
         if world_size is None:
             self.groups = get_model_parallel_group()

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -14,6 +14,7 @@ import os
 
 USE_CUDA = os.environ.get('USE_CUDA', False)
 
+# Some how xla init will slow down the CUDA speed.
 if not USE_CUDA:
     import torch_xla.core.xla_model as xm
 

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -377,10 +377,14 @@ class ColumnParallelLinear(torch.nn.Module):
         # Note: torch.nn.functional.linear performs XA^T + b and as a result
         # we allocate the transpose.
         if quant:
-            self.weight = Parameter(torch.empty((self.output_size_per_partition, self.in_features), dtype=torch.int8), requires_grad=False)
+            self.weight = Parameter(torch.empty(
+                (self.output_size_per_partition, self.in_features),
+                dtype=torch.int8),
+                                    requires_grad=False)
             self.weight_scaler = Parameter(torch.zeros(1), requires_grad=False)
         else:
-            self.weight = Parameter(torch.Tensor(self.output_size_per_partition, self.in_features))
+            self.weight = Parameter(
+                torch.Tensor(self.output_size_per_partition, self.in_features))
         if bias:
             self.bias = Parameter(torch.Tensor(self.output_size_per_partition))
             # Always initialize bias to zero.
@@ -496,10 +500,14 @@ class RowParallelLinear(torch.nn.Module):
         # Note: torch.nn.functional.linear performs XA^T + b and as a result
         # we allocate the transpose.
         if quant:
-            self.weight = Parameter(torch.empty((self.out_features, self.input_size_per_partition), dtype=torch.int8), requires_grad=False)
+            self.weight = Parameter(torch.empty(
+                (self.out_features, self.input_size_per_partition),
+                dtype=torch.int8),
+                                    requires_grad=False)
             self.weight_scaler = Parameter(torch.zeros(1), requires_grad=False)
         else:
-            self.weight = Parameter(torch.Tensor(self.out_features, self.input_size_per_partition))
+            self.weight = Parameter(
+                torch.Tensor(self.out_features, self.input_size_per_partition))
         if bias:
             self.bias = Parameter(torch.Tensor(self.out_features))
             # Always initialize bias to zero.


### PR DESCRIPTION
Summary:
This pull request enables CUDA eager and inductor for the blog branch.

1. It introduces a env called: USE_CUDA to bypass any xla init which somehow could slows down the CUDA speed.
2. It then utilizes that USE_CUDA env to distinguish scenarios where torch.dist and inductor need to be used.
3. It also introduces example_cuda.py as the driver to serve the model given torch.dist initialization is vastly different from XLA.
4. Finally, it adds a tweak for the T5 tokenizer as it doesn't have `bos` which will error out the embedding in CUDA.

Test Plan:
USE_CUDA=1 python example_cuda.py --tokenizer_path ../llama/spiece.model --max_seq_len 256 --max_batch_size 1 --temperature 0.8 --dim 4096 --n_heads 32 --n_layers 32 --mp True
PJRT_DEVICE=GPU GPU_NUM_DEVICES=4 python example_xla.py --tokenizer_path ../llama/spiece.model --max_seq_len 256 --max_batch_size 1 --temperature 0.8 --dim 4096 --n_heads 32 --n_layers 32 --mp True