### PR TITLE
Optimization for long prompt

### DIFF
--- a/example_xla.py
+++ b/example_xla.py
@@ -98,6 +98,7 @@ def main(
         ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, dim, n_layers, n_heads
     )
 
+    prompts = [generator.tokenizer.decode([8]*prompt_len) for _ in range(max_batch_size)]
     # prompts = [
         # For these prompts, the expected answer is the natural continuation of the prompt
         # "I believe the meaning of life is",
@@ -125,9 +126,8 @@ def main(
 #
 #cheese =>""",
     # ]
-    for i in range(2):
+    for _ in range(2):
         with torch.no_grad():
-            prompts = [generator.tokenizer.decode([8] * (14 - i * 10)) for _ in range(max_batch_size)]
             results = generator.generate(
                 prompts, max_gen_len=max_gen_len, temperature=temperature, top_p=top_p
             )

--- a/example_xla.py
+++ b/example_xla.py
@@ -98,7 +98,6 @@ def main(
         ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, dim, n_layers, n_heads
     )
 
-    prompts = [generator.tokenizer.decode([8]*prompt_len) for _ in range(max_batch_size)]
     # prompts = [
         # For these prompts, the expected answer is the natural continuation of the prompt
         # "I believe the meaning of life is",
@@ -126,8 +125,9 @@ def main(
 #
 #cheese =>""",
     # ]
-    for _ in range(2):
+    for i in range(2):
         with torch.no_grad():
+            prompts = [generator.tokenizer.decode([8] * (prompt_len // (i + 1))) for _ in range(max_batch_size)]
             results = generator.generate(
                 prompts, max_gen_len=max_gen_len, temperature=temperature, top_p=top_p
             )

--- a/example_xla.py
+++ b/example_xla.py
@@ -127,7 +127,7 @@ def main(
     # ]
     for i in range(2):
         with torch.no_grad():
-            prompts = [generator.tokenizer.decode([8] * (prompt_len // (i + 1))) for _ in range(max_batch_size)]
+            prompts = [generator.tokenizer.decode([8] * (14 - i * 10)) for _ in range(max_batch_size)]
             results = generator.generate(
                 prompts, max_gen_len=max_gen_len, temperature=temperature, top_p=top_p
             )

--- a/example_xla.py
+++ b/example_xla.py
@@ -98,7 +98,7 @@ def main(
         ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, dim, n_layers, n_heads
     )
 
-    prompts = [generator.tokenizer.decode([8]*prompt_len)]
+    prompts = [generator.tokenizer.decode([8]*prompt_len) for _ in range(max_batch_size)]
     # prompts = [
         # For these prompts, the expected answer is the natural continuation of the prompt
         # "I believe the meaning of life is",

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -97,9 +97,8 @@ class LLaMA:
         xm.mark_step()
 
         decoding_start_time = time.time()
-        min_section_len = 16
         prev_pos = 0
-        while prev_pos + min_section_len - 1 < min_prompt_size:
+        while prev_pos < min_prompt_size:
             section_len = 1
             while prev_pos + section_len * 2 <= min_prompt_size:
                 section_len *= 2
@@ -130,7 +129,7 @@ class LLaMA:
             xm.mark_step()
         self.model.cache_kvs = cache_kvs
         print(f"Processed prompts with {min_prompt_size} to {max_prompt_size} tokens, and generated {total_len - max_prompt_size} tokens")
-        print(f"Decoded {total_len-1} tokens in {time.time() - decoding_start_time:.5f} seconds")
+        print(f"Totally decoded {total_len - 1} tokens in {time.time() - decoding_start_time:.5f} seconds")
 
         decoded = []
         for i, t in enumerate(tokens.tolist()):

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -76,10 +76,11 @@ class LLaMA:
 
         decoding_start_time = time.time()
         prev_pos = 0
+        scale_factor = 8
         while prev_pos < min_prompt_size:
             section_len = 1
-            while prev_pos + section_len * 2 <= min_prompt_size:
-                section_len *= 2
+            while prev_pos + section_len * scale_factor <= min_prompt_size:
+                section_len *= scale_factor
             cur_pos = prev_pos + section_len
             print(f"Processing prompt pos [{prev_pos}, {cur_pos}), section length {section_len}")
             cur_pos_tensor = torch.tensor(cur_pos).to(device)

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -43,20 +43,6 @@ class LLaMA:
 
         return tokens, input_tokens, cur_pos_tensor, input_pos_tensor, output_pos_tensor, cache_kvs
 
-#    def _create_start_pos_buckets(self, max_seq_len):
-#        buckets = [max_seq_len]
-#        while buckets[-1] > 64:
-#            buckets.append(buckets[-1] // 2)
-#        buckets.append(1)
-#        buckets.reverse()
-#
-#        return buckets
-#
-#    def _select_start_pos_bucket(self, prompt_size, buckets):
-#        for i in range(1, len(buckets)):
-#            if prompt_size < buckets[i]:
-#                return buckets[i - 1]
-
     def generate(
         self,
         prompts: List[str],
@@ -85,14 +71,6 @@ class LLaMA:
         tokens = tokens.to(device)
         input_text_mask = tokens != self.tokenizer.pad_id
 
-        # start_pos = 1
-        # start_pos_buckets = self._create_start_pos_buckets(params.max_seq_len)
-        # start_pos = self._select_start_pos_bucket(min_prompt_size, start_pos_buckets)
-        # print(f"start_pos = {start_pos}")
-        # cur_pos_tensor = torch.tensor(start_pos).to(device)
-        # input_pos_tensor = torch.arange(0, start_pos).to(device)
-        # output_pos_tensor = cur_pos_tensor - 1
-        # input_tokens = tokens.index_select(1, input_pos_tensor)
         cache_kvs = self.model.cache_kvs
         xm.mark_step()
 


### PR DESCRIPTION
Implement optimization for processing long prompt.

Original pytorch generation code processes the whole prompt sequence in one `forward()` pass. This forward pass computes the cached keys and vals for all the prompt tokens, which are needed for the subsequent decoding. Then it starts to generate new tokens 1 at a time.
In XLA optimized algorithm, we process 1 prompt token at a time to avoid dynamism and graph recompilation caused by varying prompt lengths. This works well when the prompt length is short, but would be inefficient when prompt is long (1000+ tokens).

To optimize for long prompt case and strike a balance between graph compilation and efficiency, exponentially scaled prompt processing is implemented in this PR.

Example:
65B model on V4-32 with arguments: `--max_seq_len 2048 --max_batch_size 1 --prompt_len 1500 --max_gen_len 256`

**The warmed-up total time reduced from 30.13373 seconds to 4.40351 seconds.**

Before PR:
* Warmup pass: compiles 1 major graph, **executed 1756 major graphs**
  `"Decoded 1756 tokens in 174.13809 seconds"`
* Second pass: **executed 1756 major graphs**
  `"Decoded 1756 tokens in 30.13373 seconds"`

After PR:
* Warmup pass: compiles 4 major graphs, **executed 272 major graphs**
  `"Processed prompts with 1501 to 1501 tokens, and generated 256 tokens"`
  `"Totally decoded 1756 tokens in 643.19650 seconds"`
* Second pass: **executed 272 major graphs**
  `"Processed prompts with 1501 to 1501 tokens, and generated 256 tokens"`
  `"Totally decoded 1756 tokens in 4.40351 seconds"`
* 4 graph compiled are for input lengths 512, 64, 8, and 1. They can cover any future prompt lengths between 1 and 2047. In this example, they are used to process the 1501 prompt length in the following manner automatically:
"Processing prompt pos [0, 512), section length 512
Processing prompt pos [512, 1024), section length 512
Processing prompt pos [1024, 1088), section length 64
Processing prompt pos [1088, 1152), section length 64
Processing prompt pos [1152, 1216), section length 64
Processing prompt pos [1216, 1280), section length 64
Processing prompt pos [1280, 1344), section length 64
Processing prompt pos [1344, 1408), section length 64
Processing prompt pos [1408, 1472), section length 64
Processing prompt pos [1472, 1480), section length 8
Processing prompt pos [1480, 1488), section length 8
Processing prompt pos [1488, 1496), section length 8
Processing prompt pos [1496, 1497), section length 1
Processing prompt pos [1497, 1498), section length 1
Processing prompt pos [1498, 1499), section length 1
Processing prompt pos [1499, 1500), section length 1
Processing prompt pos [1500, 1501), section length 1"
