### PR TITLE
Use torch.cuda.HalfTensor for CUDA

### DIFF
--- a/example_xla.py
+++ b/example_xla.py
@@ -73,7 +73,10 @@ def load(
                                       **params)
     tokenizer = Tokenizer(model_path=tokenizer_path)
     model_args.vocab_size = tokenizer.n_words
-    torch.set_default_tensor_type(torch.BFloat16Tensor)
+    if USE_CUDA:
+        torch.set_default_tensor_type(torch.cuda.HalfTensor)
+    else:
+        torch.set_default_tensor_type(torch.BFloat16Tensor)
     model = Transformer(model_args)
     if ckpt_dir:
         model.load_state_dict(checkpoint, strict=False)


### PR DESCRIPTION
Summary:
Somehow torch.BFloat16Tensor is not working with torch.multinomial. Change it to torch.cuda.HalfTensor.

Test Plan:
USE_CUDA=1 python example_cuda.py --tokenizer_path ../llama/spiece.model --max_seq_len 256 --max_batch_size 1 --temperature 0.8 --dim 4096 --n_heads 32 --n_layers 32 --mp True