### PR TITLE
Replace all_gather with all_reduce

### DIFF
--- a/example_xla.py
+++ b/example_xla.py
@@ -73,7 +73,10 @@ def load(
                                       **params)
     tokenizer = Tokenizer(model_path=tokenizer_path)
     model_args.vocab_size = tokenizer.n_words
-    torch.set_default_tensor_type(torch.BFloat16Tensor)
+    if USE_CUDA:
+        torch.set_default_tensor_type(torch.cuda.HalfTensor)
+    else:
+        torch.set_default_tensor_type(torch.BFloat16Tensor)
     model = Transformer(model_args)
     if ckpt_dir:
         model.load_state_dict(checkpoint, strict=False)

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -173,11 +173,18 @@ def my_gather(input_: torch.Tensor, groups, world_size, rank) -> torch.Tensor:
 
     if USE_CUDA:
         last_dim = input_.dim() - 1
-        output = torch.ops.c10d_functional.all_gather_into_tensor(
-            input_, TAG, RANKSET, GROUP_SIZE)
-        if last_dim != 0:
-            output = torch.cat(torch.chunk(output, GROUP_SIZE, dim=0),
-                               dim=last_dim)
+
+        # Using all_reduce to achieve all_gather as torch.ops.c10d_functional.all_gather_into_tensor
+        # is buggy in 16 bits.
+        size = input_.size(last_dim)
+        padding = [0] * (2 * input_.dim())
+        ordinal = rank
+        left, right = ordinal, world_size - 1 - ordinal
+        idx = input_.dim() - 1 - last_dim
+        padding[2 * idx] = left * size
+        padding[2 * idx + 1] = right * size
+        output = torch.ops.c10d_functional.all_reduce(F.pad(input_, padding), "sum", TAG,
+                                                      RANKSET, GROUP_SIZE)
     else:
         output = xm.all_gather(input_, dim=-1, groups=groups)
 

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -183,8 +183,9 @@ def my_gather(input_: torch.Tensor, groups, world_size, rank) -> torch.Tensor:
         idx = input_.dim() - 1 - last_dim
         padding[2 * idx] = left * size
         padding[2 * idx + 1] = right * size
-        output = torch.ops.c10d_functional.all_reduce(F.pad(input_, padding), "sum", TAG,
-                                                      RANKSET, GROUP_SIZE)
+        output = torch.ops.c10d_functional.all_reduce(F.pad(input_,
+                                                            padding), "sum",
+                                                      TAG, RANKSET, GROUP_SIZE)
     else:
         output = xm.all_gather(input_, dim=-1, groups=groups)
 


### PR DESCRIPTION
Summary:
Somehow torch.ops.c10d_functional.all_gather_into_tensor is very buggy while being used with 16bits floats like BF16 or HalfTensor. It will produce NaN somehow. Therefore using all_reduce to achieve all_gather here.

Test Plan:
USE_CUDA=1 python example_cuda.py --tokenizer_path t5_tokenizer/spiece.model --max_seq_len 256 --max_batch_size 1 --temperature 0.8 --dim 4096 --n_heads 32 --n_layers 32 --mp True