### PR TITLE
Turn `temperature` and `top_p` into tensors

### DIFF
--- a/example_xla.py
+++ b/example_xla.py
@@ -127,9 +127,9 @@ def main(
     # ]
 
     pairs = []
-    for l in [1500, 1600, 100, 500, 800]:
-        for t in [0.1, 0.5, 0.8]:
-            for p in [0.8, 0.8]:
+    for l in [1500]:
+        for t in [0.1, 0.5]:
+            for p in [0.8, 0.9]:
                 pairs.append([l, t, p])
 
     for l, t, p in pairs:

--- a/example_xla.py
+++ b/example_xla.py
@@ -98,6 +98,7 @@ def main(
         ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, dim, n_layers, n_heads
     )
 
+    prompts = [generator.tokenizer.decode([8]*prompt_len) for _ in range(max_batch_size)]
     # prompts = [
         # For these prompts, the expected answer is the natural continuation of the prompt
         # "I believe the meaning of life is",
@@ -125,19 +126,10 @@ def main(
 #
 #cheese =>""",
     # ]
-
-    pairs = []
-    for l in [1500]:
-        for t in [0.1, 0.5, 0]:
-            for p in [0.8, 0.9]:
-                pairs.append([l, t, p])
-
-    for l, t, p in pairs:
-        print(l, t, p)
-        prompts = [generator.tokenizer.decode([8]*l) for _ in range(max_batch_size)]
+    for _ in range(2):
         with torch.no_grad():
             results = generator.generate(
-                prompts, max_gen_len=max_gen_len, temperature=t, top_p=p
+                prompts, max_gen_len=max_gen_len, temperature=temperature, top_p=top_p
             )
 
         for result in results:

--- a/example_xla.py
+++ b/example_xla.py
@@ -98,7 +98,6 @@ def main(
         ckpt_dir, tokenizer_path, rank, world_size, max_seq_len, max_batch_size, dim, n_layers, n_heads
     )
 
-    prompts = [generator.tokenizer.decode([8]*prompt_len) for _ in range(max_batch_size)]
     # prompts = [
         # For these prompts, the expected answer is the natural continuation of the prompt
         # "I believe the meaning of life is",
@@ -126,10 +125,18 @@ def main(
 #
 #cheese =>""",
     # ]
-    for _ in range(2):
+
+    pairs = []
+    for l in [1500, 1600, 100, 500, 800]:
+        for t in [0.1, 0.5, 0.8]:
+            for p in [0.8, 0.8]:
+                pairs.append([l, t, p])
+
+    for l, t, p in pairs:
+        prompts = [generator.tokenizer.decode([8]*l) for _ in range(max_batch_size)]
         with torch.no_grad():
             results = generator.generate(
-                prompts, max_gen_len=max_gen_len, temperature=temperature, top_p=top_p
+                prompts, max_gen_len=max_gen_len, temperature=t, top_p=p
             )
 
         for result in results:

--- a/example_xla.py
+++ b/example_xla.py
@@ -128,7 +128,7 @@ def main(
 
     pairs = []
     for l in [1500]:
-        for t in [0.1, 0.5]:
+        for t in [0.1, 0.5, 0]:
             for p in [0.8, 0.9]:
                 pairs.append([l, t, p])
 

--- a/example_xla.py
+++ b/example_xla.py
@@ -133,6 +133,7 @@ def main(
                 pairs.append([l, t, p])
 
     for l, t, p in pairs:
+        print(l, t, p)
         prompts = [generator.tokenizer.decode([8]*l) for _ in range(max_batch_size)]
         with torch.no_grad():
             results = generator.generate(

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -23,11 +23,11 @@ class LLaMA:
                             input_pos_tensor, output_pos_tensor, cache_kvs,
                             temperature_tensor, top_p_tensor):
         logits, cache_kvs = self.model(input_tokens, input_pos_tensor, output_pos_tensor, cache_kvs)
-        if temperature_tensor.item() > 0:
-            probs = torch.softmax(logits / temperature_tensor, dim=-1)
-            next_token = sample_top_p(probs, top_p_tensor)
-        else:
-            next_token = torch.argmax(logits, dim=-1)
+        #if temperature_tensor.item() > 0:
+        probs = torch.softmax(logits / temperature_tensor, dim=-1)
+        next_token = sample_top_p(probs, top_p_tensor)
+        #else:
+        #    next_token = torch.argmax(logits, dim=-1)
         next_token = next_token.reshape(-1)
         # only replace token if prompt has already been generated
         input_text_mask_tmp = input_text_mask.index_select(1, cur_pos_tensor).squeeze(dim=1)

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -20,10 +20,10 @@ class LLaMA:
                                                     backend="torchxla_trace_once", fullgraph=True)
 
     def _generate_one_token(self, tokens, input_tokens, input_text_mask, cur_pos_tensor, 
-                            input_pos_tensor, output_pos_tensor, cache_kvs, temperature,
+                            input_pos_tensor, output_pos_tensor, cache_kvs,
                             temperature_tensor, top_p_tensor):
         logits, cache_kvs = self.model(input_tokens, input_pos_tensor, output_pos_tensor, cache_kvs)
-        if temperature > 0:
+        if temperature_tensor.item() > 0:
             probs = torch.softmax(logits / temperature_tensor, dim=-1)
             next_token = sample_top_p(probs, top_p_tensor)
         else:
@@ -96,7 +96,7 @@ class LLaMA:
             tokens, input_tokens, cur_pos_tensor, input_pos_tensor, output_pos_tensor, cache_kvs \
                 = self._generate_one_token_fn(
                     tokens, input_tokens, input_text_mask, cur_pos_tensor,
-                    input_pos_tensor, output_pos_tensor, cache_kvs, temperature,
+                    input_pos_tensor, output_pos_tensor, cache_kvs,
                     temperature_tensor, top_p_tensor
                 )
             xm.mark_step()
@@ -108,7 +108,7 @@ class LLaMA:
             tokens, input_tokens, cur_pos_tensor, input_pos_tensor, output_pos_tensor, cache_kvs \
                 = self._generate_one_token_fn(
                     tokens, input_tokens, input_text_mask, cur_pos_tensor,
-                    input_pos_tensor, output_pos_tensor, cache_kvs, temperature,
+                    input_pos_tensor, output_pos_tensor, cache_kvs,
                     temperature_tensor, top_p_tensor
                 )
             xm.mark_step()

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -20,11 +20,12 @@ class LLaMA:
                                                     backend="torchxla_trace_once", fullgraph=True)
 
     def _generate_one_token(self, tokens, input_tokens, input_text_mask, cur_pos_tensor, 
-                            input_pos_tensor, output_pos_tensor, cache_kvs, temperature, top_p):
+                            input_pos_tensor, output_pos_tensor, cache_kvs, temperature,
+                            temperature_tensor, top_p_tensor):
         logits, cache_kvs = self.model(input_tokens, input_pos_tensor, output_pos_tensor, cache_kvs)
         if temperature > 0:
-            probs = torch.softmax(logits / temperature, dim=-1)
-            next_token = sample_top_p(probs, top_p)
+            probs = torch.softmax(logits / temperature_tensor, dim=-1)
+            next_token = sample_top_p(probs, top_p_tensor)
         else:
             next_token = torch.argmax(logits, dim=-1)
         next_token = next_token.reshape(-1)
@@ -71,6 +72,9 @@ class LLaMA:
         tokens = tokens.to(device)
         input_text_mask = tokens != self.tokenizer.pad_id
 
+        temperature_tensor = torch.tensor(temperature).to(device)
+        top_p_tensor = torch.tensor(top_p).to(device)
+
         cache_kvs = self.model.cache_kvs
         xm.mark_step()
 
@@ -92,7 +96,8 @@ class LLaMA:
             tokens, input_tokens, cur_pos_tensor, input_pos_tensor, output_pos_tensor, cache_kvs \
                 = self._generate_one_token_fn(
                     tokens, input_tokens, input_text_mask, cur_pos_tensor,
-                    input_pos_tensor, output_pos_tensor, cache_kvs, temperature, top_p
+                    input_pos_tensor, output_pos_tensor, cache_kvs, temperature,
+                    temperature_tensor, top_p_tensor
                 )
             xm.mark_step()
 
@@ -103,7 +108,8 @@ class LLaMA:
             tokens, input_tokens, cur_pos_tensor, input_pos_tensor, output_pos_tensor, cache_kvs \
                 = self._generate_one_token_fn(
                     tokens, input_tokens, input_text_mask, cur_pos_tensor,
-                    input_pos_tensor, output_pos_tensor, cache_kvs, temperature, top_p
+                    input_pos_tensor, output_pos_tensor, cache_kvs, temperature,
+                    temperature_tensor, top_p_tensor
                 )
             xm.mark_step()
         self.model.cache_kvs = cache_kvs
@@ -133,7 +139,7 @@ class LLaMA:
 def sample_top_p(probs, p):
     probs_sort, probs_idx = torch.sort(probs, dim=-1, descending=True)
     probs_sum = torch.cumsum(probs_sort, dim=-1)
-    mask = probs_sum - probs_sort > p
+    mask = (probs_sum - probs_sort) > p
     probs_sort = torch.where(mask, 0.0, probs_sort)
     probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
     next_token = torch.multinomial(probs_sort, num_samples=1)

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -72,6 +72,8 @@ class LLaMA:
         tokens = tokens.to(device)
         input_text_mask = tokens != self.tokenizer.pad_id
 
+        # Passing tensors instead of floats into self._generate_one_token_fn,
+        # so that different values would not trigger compilations of new graphs
         temperature_tensor = torch.tensor(temperature).to(device)
         top_p_tensor = torch.tensor(top_p).to(device)
         with_temp = temperature > 0

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -74,6 +74,7 @@ class LLaMA:
 
         temperature_tensor = torch.tensor(temperature).to(device)
         top_p_tensor = torch.tensor(top_p).to(device)
+        with_temp = temperature > 0
 
         cache_kvs = self.model.cache_kvs
         xm.mark_step()
@@ -97,7 +98,7 @@ class LLaMA:
                 = self._generate_one_token_fn(
                     tokens, input_tokens, input_text_mask, cur_pos_tensor,
                     input_pos_tensor, output_pos_tensor, cache_kvs,
-                    temperature_tensor, top_p_tensor, temperature > 0
+                    temperature_tensor, top_p_tensor, with_temp
                 )
             xm.mark_step()
 
@@ -109,7 +110,7 @@ class LLaMA:
                 = self._generate_one_token_fn(
                     tokens, input_tokens, input_text_mask, cur_pos_tensor,
                     input_pos_tensor, output_pos_tensor, cache_kvs,
-                    temperature_tensor, top_p_tensor, temperature > 0
+                    temperature_tensor, top_p_tensor, with_temp
                 )
             xm.mark_step()
         self.model.cache_kvs = cache_kvs


### PR DESCRIPTION
Turn `temperature` and `top_p` into tensors, so there would be no recompilation for different `(temperature, top_p)` combinations. Note that temperature=0 and temperature>0 would still have different graphs because the computation logics are different.