### PR TITLE
Llama2 gpu google next inference

### DIFF
--- a/example_text_completion.py
+++ b/example_text_completion.py
@@ -89,8 +89,6 @@ def _fn(
     dynamo: bool = True,
 ):
     if USE_CUDA:
-        print(f"CUDA available? {torch.cuda.is_available()} idx {idx}")
-        print(f"USE_CUDA world size {torch.cuda.device_count()} idx {idx}")
         os.environ['WORLD_SIZE'] = str(torch.cuda.device_count())
         os.environ['RANK'] = str(idx)
         os.environ['LOCAL_RANK'] = str(idx)

--- a/example_text_completion.py
+++ b/example_text_completion.py
@@ -79,9 +79,11 @@ def _fn(
     dynamo: bool = True,
 ):
     if USE_CUDA:
-        os.environ['WORLD_SIZE'] = torch.cuda.device_count()
-        os.environ['RANK'] = idx
-        os.environ['LOCAL_RANK'] = idx
+        print(f"CUDA available? {torch.cuda.is_available()} idx {idx}")
+        print(f"USE_CUDA world size {torch.cuda.device_count()} idx {idx}")
+        os.environ['WORLD_SIZE'] = str(torch.cuda.device_count())
+        os.environ['RANK'] = str(idx)
+        os.environ['LOCAL_RANK'] = str(idx)
     main(ckpt_dir, tokenizer_path, temperature, top_p, max_seq_len, max_gen_len, max_batch_size, dynamo)
 
 

--- a/llama/model.py
+++ b/llama/model.py
@@ -34,6 +34,7 @@ class ModelArgs:
     max_batch_size: int = 32
     max_seq_len: int = 2048
     quant: bool = False
+    gpu: bool = False
 
 
 class RMSNorm(torch.nn.Module):
@@ -129,6 +130,7 @@ class Attention(nn.Module):
             rank=rank,
             groups=groups,
             quant=args.quant,
+            gpu=args.gpu,
         )
         self.wk = ColumnParallelLinear(
             args.dim,
@@ -140,6 +142,7 @@ class Attention(nn.Module):
             rank=rank,
             groups=groups,
             quant=args.quant,
+            gpu=args.gpu,
         )
         self.wv = ColumnParallelLinear(
             args.dim,
@@ -151,6 +154,7 @@ class Attention(nn.Module):
             rank=rank,
             groups=groups,
             quant=args.quant,
+            gpu=args.gpu,
         )
         self.wo = RowParallelLinear(
             args.n_heads * self.head_dim,
@@ -162,6 +166,7 @@ class Attention(nn.Module):
             rank=rank,
             groups=groups,
             quant=args.quant,
+            gpu=args.gpu,
         )
 
         cache_k = torch.zeros(
@@ -231,6 +236,7 @@ class FeedForward(nn.Module):
         rank: Optional[int] = None,
         groups: Optional[List] = None,
         quant: bool = False,
+        gpu: bool = False,
     ):
         super().__init__()
         hidden_dim = int(2 * hidden_dim / 3)
@@ -256,6 +262,7 @@ class FeedForward(nn.Module):
             rank=rank,
             groups=groups,
             quant=quant,
+            gpu=gpu,
         )
         self.w2 = RowParallelLinear(
             hidden_dim,
@@ -267,6 +274,7 @@ class FeedForward(nn.Module):
             rank=rank,
             groups=groups,
             quant=quant,
+            gpu=gpu,
         )
         self.w3 = ColumnParallelLinear(
             dim,
@@ -278,6 +286,7 @@ class FeedForward(nn.Module):
             rank=rank,
             groups=groups,
             quant=quant,
+            gpu=gpu,
         )
 
     def forward(self, x):
@@ -316,6 +325,7 @@ class TransformerBlock(nn.Module):
             rank=rank,
             groups=groups,
             quant=args.quant,
+            gpu=args.gpu,
         )
         self.layer_id = layer_id
         self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
@@ -382,6 +392,7 @@ class Transformer(nn.Module):
             rank=rank,
             groups=groups,
             quant=params.quant,
+            gpu=params.gpu,
         )
 
         freqs_cis = precompute_freqs_cis(

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -428,8 +428,8 @@ class ColumnParallelLinear(torch.nn.Module):
                                                        self.rank)
         # Matrix multiply.
         if self.quant:
-            output_parallel = F.linear(input_parallel, self.weight, self.bias)
-            output_parallel = output_parallel * self.weight_scaler
+            scaled_weight = self.weight * self.weight_scaler
+            output_parallel = F.linear(input_parallel, scaled_weight, self.bias)
         else:
             output_parallel = F.linear(input_parallel, self.weight, self.bias)
         if self.gather_output:
@@ -552,8 +552,8 @@ class RowParallelLinear(torch.nn.Module):
                 input_, self.groups, self.world_size, self.rank)
         # Matrix multiply.
         if self.quant:
-            output_parallel = F.linear(input_parallel, self.weight, self.bias)
-            output_parallel = output_parallel * self.weight_scaler
+            scaled_weight = self.weight * self.weight_scaler
+            output_parallel = F.linear(input_parallel, scaled_weight, self.bias)
         else:
             output_parallel = F.linear(input_parallel, self.weight)
         # All-reduce across all the partitions.

--- a/llama/xla_model_parallel.py
+++ b/llama/xla_model_parallel.py
@@ -311,6 +311,11 @@ class ParallelEmbedding(torch.nn.Module):
         input_parallel = copy_to_model_parallel_region(input_, self.groups,
                                                        self.world_size,
                                                        self.rank)
+        # print("input", input_parallel)
+        # print("weight shape", torch.numel(self.weight), self.weight.shape)
+        # This is a hack - the first call, input parallel contains a  -1 that generates an assert.
+        # Take the modulus avoid this error 
+        input_parallel = torch.remainder(input_parallel, self.weight.shape[0])
         output_parallel = F.embedding(
             input_parallel,
             self.weight,


### PR DESCRIPTION
Merging in the GPU changes. 
Confirmed that all GPU changes are wrapped and do not affect TPU. Following test was run on v4-8.
When running on GPUs add ‘gpu: true’ is added to params.json to enable these changes.

No quantization:
Branch: llama2-google-next-inference
$PJRT_DEVICE=TPU python3 example_text_completion.py --ckpt_dir ~/ckpt/13b --tokenizer_path ~/llama1/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 12 --mp True --dynamo True
Cold:
Processed prompts with 8 to 8 tokens, and generated 1000 tokens
Totally decoded 1007 tokens in 135.18263 seconds
Warm:
Processed prompts with 8 to 8 tokens, and generated 1000 tokens
Totally decoded 1007 tokens in 28.06329 seconds


Branch: llama2-gpu-google-next-inference
$ PJRT_DEVICE=TPU python3 example_text_completion.py --ckpt_dir ~/ckpt/13b --tokenizer_path ~/llama1/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 12 --mp True --dynamo True
Cold:
Processed prompts with 8 to 8 tokens, and generated 1000 tokens
Totally decoded 1007 tokens in 134.80040 seconds
Warm
Processed prompts with 8 to 8 tokens, and generated 1000 tokens
Totally decoded 1007 tokens in 28.12496 seconds



With quantization
Branch: llama2-google-next-inference
$PJRT_DEVICE=TPU python3 example_text_completion.py --ckpt_dir ~/ckpt/13b --tokenizer_path ~/llama1/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 12 --mp True --dynamo True
Cold
Processed prompts with 8 to 8 tokens, and generated 1000 tokens
Totally decoded 1007 tokens in 156.66985 seconds
Warm:
Processed prompts with 8 to 8 tokens, and generated 1000 tokens
Totally decoded 1007 tokens in 27.43947 seconds


Branch: llama2-gpu-google-next-inference
$ PJRT_DEVICE=TPU python3 example_text_completion.py --ckpt_dir ~/ckpt/13b --tokenizer_path ~/llama1/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 12 --mp True --dynamo True

Cold:
Processed prompts with 8 to 8 tokens, and generated 1000 tokens
Totally decoded 1007 tokens in 160.68077 seconds
Warm: 
Processed prompts with 8 to 8 tokens, and generated 1000 tokens
Totally decoded 1007 tokens in 27.49051 seconds