### PR TITLE
Update inference to use `openxla_eval` backend

### DIFF
--- a/llama/generation.py
+++ b/llama/generation.py
@@ -134,7 +134,7 @@ class Llama:
             else:
                 self._generate_one_token_fn = torch.compile(
                     self._generate_one_token_fn,
-                    backend="torchxla_trace_once",
+                    backend="openxla_eval",
                     fullgraph=True)
 
     def _generate_one_token(self, tokens, input_tokens, input_text_mask,


### PR DESCRIPTION
`openxla_eval` and `torchxla_trace_once` are the same backend with different name, check https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/backends/torchxla.py#L17-L28

The only difference is that `torchxla_trace_once` will throw a deprecation warning message.