### PR TITLE
allow setting of dynamo backend via command line

### DIFF
--- a/TORCH_XLA_USER_GUIDE.md
+++ b/TORCH_XLA_USER_GUIDE.md
@@ -62,7 +62,7 @@ pip3 install -r requirements.txt
 pip3 install -e ."
 
 gcloud compute tpus tpu-vm ssh ${TPU_NAME} --zone ${ZONE} --project ${PROJECT_ID} --worker=all --command="cd $HOME/llama && 
-PJRT_DEVICE=TPU XLA_FLAGS=--xla_dump_to=/tmp/dir_name PROFILE_LOGDIR=/tmp/home/ python3 example_text_completion.py --ckpt_dir . --tokenizer_path $HOME/llama/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 2 --mp True --dynamo True"
+PJRT_DEVICE=TPU XLA_FLAGS=--xla_dump_to=/tmp/dir_name PROFILE_LOGDIR=/tmp/home/ python3 example_text_completion.py --ckpt_dir . --tokenizer_path $HOME/llama/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 2 --mp True --dynamo openxla_eval"
 ```
 
 ## Commands to Run Llama2 using XLA:TPU (TPU v4)
@@ -89,7 +89,7 @@ pip3 install -e ."
 gcloud compute tpus tpu-vm scp params_70b.json ${TPU_NAME}:params.json --zone ${ZONE} --project ${PROJECT_ID} --worker=all
 
 gcloud compute tpus tpu-vm ssh ${TPU_NAME} --zone ${ZONE} --project ${PROJECT_ID} --worker=all --command="cd $HOME/llama && 
-PJRT_DEVICE=TPU XLA_FLAGS=--xla_dump_to=/tmp/dir_name PROFILE_LOGDIR=/tmp/home/ python3.8 example_text_completion.py --ckpt_dir . --tokenizer_path $HOME/llama/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 2 --mp True --dynamo True"
+PJRT_DEVICE=TPU XLA_FLAGS=--xla_dump_to=/tmp/dir_name PROFILE_LOGDIR=/tmp/home/ python3.8 example_text_completion.py --ckpt_dir . --tokenizer_path $HOME/llama/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 2 --mp True --dynamo openxla_eval"
 ```
 ## Commands to Run Llama2 using XLA:GPU (e.g. L4 or H100)
 
@@ -97,9 +97,13 @@ PJRT_DEVICE=TPU XLA_FLAGS=--xla_dump_to=/tmp/dir_name PROFILE_LOGDIR=/tmp/home/ 
 that you have XLA:GPU support. Please refer to [pytorch/xla](https://github.com/pytorch/xla#wheel) repo to download
 a suitable GPU nightly wheel for your environment.
 
-After that, you can run the following the command:
+After that, you can run with XLA:GPU using the following the command:
 ```
-PJRT_DEVICE=GPU GPU_NUM_DEVICES=8 python3 example_text_completion.py 1 --ckpt_dir . --tokenizer_path $HOME/llama/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 1 --dynamo True --mp True
+PJRT_DEVICE=CUDA GPU_NUM_DEVICES=8 python3 example_text_completion.py 1 --ckpt_dir . --tokenizer_path $HOME/llama/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 1 --dynamo openxla_eval --mp True
+```
+To run with Inductor:
+```
+CUDA_VISIBLE_DEVICES=0 USE_CUDA=1 python3 example_text_completion.py 1 --ckpt_dir . --tokenizer_path $HOME/llama/t5_tokenizer/spiece.model --max_seq_len 2048 --max_gen_len 1000 --max_batch_size 1 --dynamo inductor --mp True
 ```
 
 For H100, we suggest to use docker image with ubuntu2024 in created H100 GPUVM: `gcr.io/tpu-pytorch/xla/ubuntu_2024_cuda_118:test`

--- a/example_text_completion.py
+++ b/example_text_completion.py
@@ -25,7 +25,7 @@ def main(
     max_seq_len: int = 128,
     max_gen_len: int = 64,
     max_batch_size: int = 4,
-    dynamo: bool = True,
+    dynamo: str = "openxla_eval",
     repeat: int = 2,
 ):
     if not USE_CUDA:
@@ -87,7 +87,7 @@ def _fn(
     max_seq_len: int = 128,
     max_gen_len: int = 64,
     max_batch_size: int = 4,
-    dynamo: bool = True,
+    dynamo: str = "openxla_eval",
     repeat: int = 2,
 ):
     if USE_CUDA:
@@ -106,9 +106,17 @@ def mp_main(
     max_seq_len: int = 128,
     max_gen_len: int = 64,
     max_batch_size: int = 4,
-    dynamo: bool = True,
+    dynamo: str = "openxla_eval",
     repeat: int = 2,
 ):
+    # Sanity-check the combination of USE_CUDA envvar and --dynamo flag.
+    if USE_CUDA:
+        # Eager mode on GPU or Inductor.
+        assert not dynamo or dynamo == "inductor"
+    else:
+        # Eager CPU / OpenXLA+Lazytensor (if PJRT_DEVICE is set), or OpenXLA.
+        assert not dynamo or dynamo == "openxla" or dynamo == "openxla_eval"
+
     if mp:
         if USE_CUDA:
             kwargs = {"nprocs": torch.cuda.device_count(),

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -59,7 +59,7 @@ class Llama:
         max_seq_len: int,
         max_batch_size: int,
         model_parallel_size: Optional[int] = None,
-        dynamo: bool = True,
+        dynamo: str = "openxla_eval",
     ) -> "Llama":
         # if not model_parallel_is_initialized():
         #     if model_parallel_size is None:
@@ -120,7 +120,7 @@ class Llama:
 
         return Llama(model, tokenizer, device, dynamo)
 
-    def __init__(self, model: Transformer, tokenizer: Tokenizer, device: torch.device, dynamo: bool = True):
+    def __init__(self, model: Transformer, tokenizer: Tokenizer, device: torch.device, dynamo: str = "openxla_eval"):
         self.model = model
         self.tokenizer = tokenizer
         self.device = device
@@ -134,7 +134,7 @@ class Llama:
             else:
                 self._generate_one_token_fn = torch.compile(
                     self._generate_one_token_fn,
-                    backend="openxla_eval",
+                    backend=dynamo,
                     fullgraph=True)
 
     def _generate_one_token(self, tokens, input_tokens, input_text_mask,


### PR DESCRIPTION
This will allow us to run with either `openxla` or `openxla_eval`, and takes us closer to a future in which `USE_CUDA` is not needed for Inductor.