### PR TITLE
Add flag to enable activation sharding

### DIFF
--- a/example_text_completion.py
+++ b/example_text_completion.py
@@ -26,6 +26,7 @@ def main(
     max_batch_size: int = 4,
     dynamo: bool = True,
     spmd: bool = True,
+    enable_activation_sharding: bool = False,
 ):
     if not USE_CUDA:
         # server = xp.start_server(9012, only_on_master=False)
@@ -37,6 +38,7 @@ def main(
         max_batch_size=max_batch_size,
         dynamo=dynamo,
         spmd=spmd,
+        enable_activation_sharding=enable_activation_sharding,
     )
 
     print(f'[WONJOO] max_batch_size={max_batch_size}')
@@ -60,9 +62,9 @@ def main(
     ]
 
     import time
-    print("About to start in 15 seconds")
-    server = xp.start_server(9012, only_on_master=False)
-    time.sleep(15)
+    # print("About to start in 10 seconds")
+    # server = xp.start_server(9012, only_on_master=False)
+    # time.sleep(10)
     print("Starting!")
 
     for _ in range(2):
@@ -92,12 +94,13 @@ def _fn(
     max_batch_size: int = 4,
     dynamo: bool = True,
     spmd: bool = True,
+    enable_activation_sharding: bool = False,
 ):
     if USE_CUDA:
         os.environ['WORLD_SIZE'] = torch.cuda.device_count()
         os.environ['RANK'] = idx
         os.environ['LOCAL_RANK'] = idx
-    main(ckpt_dir, tokenizer_path, temperature, top_p, max_seq_len, max_gen_len, max_batch_size, dynamo, spmd)
+    main(ckpt_dir, tokenizer_path, temperature, top_p, max_seq_len, max_gen_len, max_batch_size, dynamo, spmd, enable_activation_sharding)
 
 
 def mp_main(
@@ -111,6 +114,7 @@ def mp_main(
     max_batch_size: int = 4,
     dynamo: bool = True,
     spmd: bool = True,
+    enable_activation_sharding: bool = False,
 ):
     if mp:
         if USE_CUDA:
@@ -119,9 +123,9 @@ def mp_main(
         else:
             kwargs = {}
         xmp.spawn(_fn,
-                  args=(ckpt_dir, tokenizer_path, temperature, top_p, max_seq_len, max_gen_len, max_batch_size, dynamo, spmd), **kwargs)
+                  args=(ckpt_dir, tokenizer_path, temperature, top_p, max_seq_len, max_gen_len, max_batch_size, dynamo, spmd, enable_activation_sharding), **kwargs)
     else:
-        main(ckpt_dir, tokenizer_path, temperature, top_p, max_seq_len, max_gen_len, max_batch_size, dynamo, spmd)
+        main(ckpt_dir, tokenizer_path, temperature, top_p, max_seq_len, max_gen_len, max_batch_size, dynamo, spmd, enable_activation_sharding)
 
 
 if __name__ == "__main__":

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -65,6 +65,7 @@ class Llama:
         model_parallel_size: Optional[int] = None,
         dynamo: bool = True,
         spmd: bool = True,
+        enable_activation_sharding: bool = False,
     ) -> "Llama":
 
         # seed must be the same in all processes
@@ -102,9 +103,12 @@ class Llama:
         with open(Path(ckpt_dir) / "params.json", "r") as f:
             params = json.loads(f.read())
 
+        num_devices = xr.global_runtime_device_count()
         model_args: ModelArgs = ModelArgs(
             max_seq_len=max_seq_len,
             max_batch_size=max_batch_size,
+            num_devices=num_devices,
+            enable_activation_sharding=enable_activation_sharding,
             **params,
         )
 

--- a/llama/model.py
+++ b/llama/model.py
@@ -39,6 +39,8 @@ class ModelArgs:
     max_seq_len: int = 2048
     quant: bool = False
 
+    enable_activation_sharding: bool = False
+
     def print_values(self):
         print(f'[WONJOO] ModelArgs')
         print(f'[WONJOO] dim={self.dim}')
@@ -47,6 +49,7 @@ class ModelArgs:
         print(f'[WONJOO] max_batch_size={self.max_batch_size}')
         print(f'[WONJOO] max_seq_len={self.max_seq_len}')
         print(f'[WONJOO] quant={self.quant}')
+        print(f'[WONJOO] enable_activation_sharding={self.enable_activation_sharding}')
 
 
 class RMSNorm(torch.nn.Module):
@@ -124,6 +127,7 @@ class Attention(nn.Module):
         self.n_local_kv_heads = self.n_kv_heads
         self.n_rep = self.n_local_heads // self.n_local_kv_heads  # this should be 1 if args.n_kv_heads is None
         self.head_dim = args.dim // args.n_heads
+        self.enable_activation_sharding = args.enable_activation_sharding
 
         self.wq = nn.Linear(
             args.dim,
@@ -203,12 +207,16 @@ class Attention(nn.Module):
         output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
         output = self.wo(output)
 
-        # # Activation output sharding
-        # # TODO(yeounoh) remove this after activation sharding support is enabled.
-        num_devices = xr.global_runtime_device_count()
-        device_ids = torch.arange(num_devices)
-        data_model_mesh = xs.Mesh(device_ids, (4, 1, 2))
-        xs.mark_sharding(output, data_model_mesh, (0, 1, 2), use_dynamo_custom_op=True)
+        # Activation output sharding
+        import torch_xla.experimental.dynamo_mark_sharding
+        if self.enable_activation_sharding:
+            # num_devices = 8  # xr.global_runtime_device_count()
+            # device_ids = [i for i in range(num_devices)]
+            device_ids = [0, 1, 2, 3, 4, 5, 6, 7]
+            mesh_shape = [4, 1, 2]
+            axis_names = 'None'
+            partition_spec = '(0, 1, 2)'
+            torch.ops.xla.dynamo_mark_sharding(output, device_ids, mesh_shape, axis_names, partition_spec)
 
         return output
 

--- a/llama/model.py
+++ b/llama/model.py
@@ -39,6 +39,7 @@ class ModelArgs:
     max_seq_len: int = 2048
     quant: bool = False
 
+    num_devices: int = 8
     enable_activation_sharding: bool = False
 
     def print_values(self):
@@ -49,6 +50,7 @@ class ModelArgs:
         print(f'  max_batch_size={self.max_batch_size}')
         print(f'  max_seq_len={self.max_seq_len}')
         print(f'  quant={self.quant}')
+        print(f'  num_devices={self.num_devices}')
         print(f'  enable_activation_sharding={self.enable_activation_sharding}')
 
 
@@ -128,6 +130,7 @@ class Attention(nn.Module):
         self.n_rep = self.n_local_heads // self.n_local_kv_heads  # this should be 1 if args.n_kv_heads is None
         self.head_dim = args.dim // args.n_heads
         self.enable_activation_sharding = args.enable_activation_sharding
+        self.num_devices = args.num_devices
 
         self.wq = nn.Linear(
             args.dim,
@@ -211,8 +214,9 @@ class Attention(nn.Module):
         import torch_xla.experimental.dynamo_mark_sharding
         if self.enable_activation_sharding:
             # num_devices = 8  # xr.global_runtime_device_count()
-            # device_ids = [i for i in range(num_devices)]
-            device_ids = [0, 1, 2, 3, 4, 5, 6, 7]
+            device_ids = [i for i in range(self.num_devices)]
+            # device_ids = [0, 1, 2, 3, 4, 5, 6, 7]
+            # device_ids = np.arange(self.num_devices)
             mesh_shape = [4, 1, 2]
             axis_names = 'None'
             partition_spec = '(0, 1, 2)'

--- a/llama/model.py
+++ b/llama/model.py
@@ -42,14 +42,14 @@ class ModelArgs:
     enable_activation_sharding: bool = False
 
     def print_values(self):
-        print(f'[WONJOO] ModelArgs')
-        print(f'[WONJOO] dim={self.dim}')
-        print(f'[WONJOO] n_layers={self.n_layers}')
-        print(f'[WONJOO] n_heads={self.n_heads}')
-        print(f'[WONJOO] max_batch_size={self.max_batch_size}')
-        print(f'[WONJOO] max_seq_len={self.max_seq_len}')
-        print(f'[WONJOO] quant={self.quant}')
-        print(f'[WONJOO] enable_activation_sharding={self.enable_activation_sharding}')
+        print(f'ModelArgs')
+        print(f'  dim={self.dim}')
+        print(f'  n_layers={self.n_layers}')
+        print(f'  n_heads={self.n_heads}')
+        print(f'  max_batch_size={self.max_batch_size}')
+        print(f'  max_seq_len={self.max_seq_len}')
+        print(f'  quant={self.quant}')
+        print(f'  enable_activation_sharding={self.enable_activation_sharding}')
 
 
 class RMSNorm(torch.nn.Module):

--- a/llama/model.py
+++ b/llama/model.py
@@ -217,7 +217,8 @@ class Attention(nn.Module):
             device_ids = [i for i in range(self.num_devices)]
             # device_ids = [0, 1, 2, 3, 4, 5, 6, 7]
             # device_ids = np.arange(self.num_devices)
-            mesh_shape = [4, 1, 2]
+            # mesh_shape = [4, 1, 2]
+            mesh_shape = [self.num_devices//2, 1, 2]
             axis_names = 'None'
             partition_spec = '(0, 1, 2)'
             torch.ops.xla.dynamo_mark_sharding(output, device_ids, mesh_shape, axis_names, partition_spec)


### PR DESCRIPTION
With this PR, you can add flag `--enable_activation_sharding True` to your command to enable activation sharding. By default, this is set to false.